### PR TITLE
Reworked resolution scaling 

### DIFF
--- a/resources/shaders/bloom_horizontal.hlsl
+++ b/resources/shaders/bloom_horizontal.hlsl
@@ -16,11 +16,11 @@ void main_cs(int3 dispatch_thread_id : SV_DispatchThreadID)
 
 	float2 uv = (screen_coord + 0.5f) / screen_size;
 
-	float sigma = 4.0f;
+	float sigma = 6.0f;
 
 	float4 color = 0;
 	float weightSum = 0.0f;
-	for (int i = -7; i < 7; i++)
+	for (int i = -14; i < 14; i++)
 	{
 		float weight = CalcGaussianWeight(i, sigma);
 		weightSum += weight;

--- a/resources/shaders/bloom_vertical.hlsl
+++ b/resources/shaders/bloom_vertical.hlsl
@@ -16,11 +16,11 @@ void main_cs(int3 dispatch_thread_id : SV_DispatchThreadID)
 
 	float2 uv = (screen_coord + 0.5f) / screen_size;
 
-	float sigma = 4.0f;
+	float sigma = 6.0f;
 
 	float4 color = 0;
 	float weightSum = 0.0f;
-	for (int i = -7; i < 7; i++)
+	for (int i = -14; i < 14; i++)
 	{
 		float weight = CalcGaussianWeight(i, sigma);
 		weightSum += weight;

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -370,14 +370,21 @@ namespace wr
 
 			if (properties.m_width.Get().has_value() || properties.m_height.Get().has_value())
 			{
-				auto retval = d3d12::CreateRenderTarget(m_device, properties.m_width.Get().value(), properties.m_height.Get().value(), desc);
+				auto retval = d3d12::CreateRenderTarget(m_device, 
+					properties.m_width.Get().value() * properties.m_resolution_scale.Get(),
+					properties.m_height.Get().value() * properties.m_resolution_scale.Get(),
+					desc);
+
 				for (auto i = 0; i < retval->m_render_targets.size(); i++)
 					retval->m_render_targets[i]->SetName(properties.m_name.Get().c_str());
 				return retval;
 			}
 			else if (m_window.has_value())
 			{
-				auto retval = d3d12::CreateRenderTarget(m_device, m_window.value()->GetWidth(), m_window.value()->GetHeight(), desc);
+				auto retval = d3d12::CreateRenderTarget(m_device, 
+					m_window.value()->GetWidth() * properties.m_resolution_scale.Get(), 
+					m_window.value()->GetHeight() * properties.m_resolution_scale.Get(), 
+					desc);
 				for (auto i = 0; i < retval->m_render_targets.size(); i++)
 					retval->m_render_targets[i]->SetName(properties.m_name.Get().c_str());
 				return retval;

--- a/src/render_tasks/d3d12_bloom_composition.hpp
+++ b/src/render_tasks/d3d12_bloom_composition.hpp
@@ -140,7 +140,7 @@ namespace wr
 	} /* internal */
 
 	template<typename T, typename T1>
-	inline void AddBloomCompositionTask(FrameGraph& frame_graph, int32_t width, int32_t height)
+	inline void AddBloomCompositionTask(FrameGraph& frame_graph)
 	{
 		std::wstring name(L"Bloom composition");
 

--- a/src/render_tasks/d3d12_bloom_horizontal.hpp
+++ b/src/render_tasks/d3d12_bloom_horizontal.hpp
@@ -100,18 +100,15 @@ namespace wr
 	} /* internal */
 
 	template<typename T>
-	inline void AddBloomHorizontalTask(FrameGraph& frame_graph, int32_t width, int32_t height)
+	inline void AddBloomHorizontalTask(FrameGraph& frame_graph)
 	{
-		const std::uint32_t m_half_width = (uint32_t)width / 2;
-		const std::uint32_t m_half_height = (uint32_t)height / 2;
-
 		std::wstring name(L"Bloom horizontal blur");
 
 		RenderTargetProperties rt_properties
 		{
 			RenderTargetProperties::IsRenderWindow(false),
-			RenderTargetProperties::Width(m_half_width),
-			RenderTargetProperties::Height(m_half_height),
+			RenderTargetProperties::Width(std::nullopt),
+			RenderTargetProperties::Height(std::nullopt),
 			RenderTargetProperties::ExecuteResourceState(ResourceState::UNORDERED_ACCESS),
 			RenderTargetProperties::FinishedResourceState(ResourceState::COPY_SOURCE),
 			RenderTargetProperties::CreateDSVBuffer(false),

--- a/src/render_tasks/d3d12_bloom_vertical.hpp
+++ b/src/render_tasks/d3d12_bloom_vertical.hpp
@@ -100,18 +100,15 @@ namespace wr
 	} /* internal */
 
 	template<typename T>
-	inline void AddBloomVerticalTask(FrameGraph& frame_graph, int32_t width, int32_t height)
+	inline void AddBloomVerticalTask(FrameGraph& frame_graph)
 	{
-		const std::uint32_t m_half_width = (uint32_t)width / 2;
-		const std::uint32_t m_half_height = (uint32_t)height / 2;
-
 		std::wstring name(L"Bloom horizontal blur");
 
 		RenderTargetProperties rt_properties
 		{
 			RenderTargetProperties::IsRenderWindow(false),
-			RenderTargetProperties::Width(m_half_width),
-			RenderTargetProperties::Height(m_half_height),
+			RenderTargetProperties::Width(std::nullopt),
+			RenderTargetProperties::Height(std::nullopt),
 			RenderTargetProperties::ExecuteResourceState(ResourceState::UNORDERED_ACCESS),
 			RenderTargetProperties::FinishedResourceState(ResourceState::COPY_SOURCE),
 			RenderTargetProperties::CreateDSVBuffer(false),

--- a/src/render_tasks/d3d12_dof_bokeh.hpp
+++ b/src/render_tasks/d3d12_dof_bokeh.hpp
@@ -181,18 +181,15 @@ namespace wr
 	} /* internal */
 
 	template<typename T, typename T1>
-	inline void AddDoFBokehTask(FrameGraph& frame_graph, int32_t width, int32_t height)
+	inline void AddDoFBokehTask(FrameGraph& frame_graph)
 	{
-		const std::uint32_t m_half_width = (uint32_t)width / 2;
-		const std::uint32_t m_half_height = (uint32_t)height / 2;
-
 		std::wstring name(L"DoF bokeh pass");
 
 		RenderTargetProperties rt_properties
 		{
 			RenderTargetProperties::IsRenderWindow(false),
-			RenderTargetProperties::Width(m_half_width),
-			RenderTargetProperties::Height(m_half_height),
+			RenderTargetProperties::Width(std::nullopt),
+			RenderTargetProperties::Height(std::nullopt),
 			RenderTargetProperties::ExecuteResourceState(ResourceState::UNORDERED_ACCESS),
 			RenderTargetProperties::FinishedResourceState(ResourceState::COPY_SOURCE),
 			RenderTargetProperties::CreateDSVBuffer(false),

--- a/src/render_tasks/d3d12_dof_bokeh_postfilter.hpp
+++ b/src/render_tasks/d3d12_dof_bokeh_postfilter.hpp
@@ -132,18 +132,15 @@ namespace wr
 	} /* internal */
 
 	template<typename T>
-	inline void AddDoFBokehPostFilterTask(FrameGraph& frame_graph, int32_t width, int32_t height)
+	inline void AddDoFBokehPostFilterTask(FrameGraph& frame_graph)
 	{
-		const std::uint32_t m_half_width = (uint32_t)width / 2;
-		const std::uint32_t m_half_height = (uint32_t)height / 2;
-
 		std::wstring name(L"DoF bokeh post filter");
 
 		RenderTargetProperties rt_properties
 		{
 			RenderTargetProperties::IsRenderWindow(false),
-			RenderTargetProperties::Width(m_half_width),
-			RenderTargetProperties::Height(m_half_height),
+			RenderTargetProperties::Width(std::nullopt),
+			RenderTargetProperties::Height(std::nullopt),
 			RenderTargetProperties::ExecuteResourceState(ResourceState::UNORDERED_ACCESS),
 			RenderTargetProperties::FinishedResourceState(ResourceState::COPY_SOURCE),
 			RenderTargetProperties::CreateDSVBuffer(false),

--- a/src/render_tasks/d3d12_dof_dilate_flatten.hpp
+++ b/src/render_tasks/d3d12_dof_dilate_flatten.hpp
@@ -102,18 +102,15 @@ namespace wr
 	} /* internal */
 
 	template<typename T>
-	inline void AddDoFDilateFlattenTask(FrameGraph& frame_graph, int32_t width, int32_t height)
+	inline void AddDoFDilateFlattenTask(FrameGraph& frame_graph)
 	{
-		const std::uint32_t m_quarter_width = (uint32_t)width / 8;
-		const std::uint32_t m_quarter_height = (uint32_t)height / 8;
-
 		std::wstring name(L"DoF coc dilate flatten horizontal");
 
 		RenderTargetProperties rt_properties
 		{
 			RenderTargetProperties::IsRenderWindow(false),
-			RenderTargetProperties::Width(m_quarter_width),
-			RenderTargetProperties::Height(m_quarter_height),
+			RenderTargetProperties::Width(std::nullopt),
+			RenderTargetProperties::Height(std::nullopt),
 			RenderTargetProperties::ExecuteResourceState(ResourceState::UNORDERED_ACCESS),
 			RenderTargetProperties::FinishedResourceState(ResourceState::COPY_SOURCE),
 			RenderTargetProperties::CreateDSVBuffer(false),

--- a/src/render_tasks/d3d12_dof_dilate_flatten_second_pass.hpp
+++ b/src/render_tasks/d3d12_dof_dilate_flatten_second_pass.hpp
@@ -102,18 +102,15 @@ namespace wr
 	} /* internal */
 
 	template<typename T>
-	inline void AddDoFDilateFlattenHTask(FrameGraph& frame_graph, int32_t width, int32_t height)
+	inline void AddDoFDilateFlattenHTask(FrameGraph& frame_graph)
 	{
-		const std::uint32_t m_quarter_width = (uint32_t)width / 8;
-		const std::uint32_t m_quarter_height = (uint32_t)height / 8;
-
 		std::wstring name(L"DoF dilate flatten vertical pass");
 
 		RenderTargetProperties rt_properties
 		{
 			RenderTargetProperties::IsRenderWindow(false),
-			RenderTargetProperties::Width(m_quarter_width),
-			RenderTargetProperties::Height(m_quarter_height),
+			RenderTargetProperties::Width(std::nullopt),
+			RenderTargetProperties::Height(std::nullopt),
 			RenderTargetProperties::ExecuteResourceState(ResourceState::UNORDERED_ACCESS),
 			RenderTargetProperties::FinishedResourceState(ResourceState::COPY_SOURCE),
 			RenderTargetProperties::CreateDSVBuffer(false),

--- a/src/render_tasks/d3d12_dof_dilate_near.hpp
+++ b/src/render_tasks/d3d12_dof_dilate_near.hpp
@@ -101,18 +101,15 @@ namespace wr
 	} /* internal */
 
 	template<typename T>
-	inline void AddDoFDilateTask(FrameGraph& frame_graph, int32_t width, int32_t height)
+	inline void AddDoFDilateTask(FrameGraph& frame_graph)
 	{
-		const std::uint32_t m_quarter_width = (uint32_t)width / 8;
-		const std::uint32_t m_quarter_height = (uint32_t)height / 8;
-
 		std::wstring name(L"DoF dilate");
 
 		RenderTargetProperties rt_properties
 		{
 			RenderTargetProperties::IsRenderWindow(false),
-			RenderTargetProperties::Width(m_quarter_width),
-			RenderTargetProperties::Height(m_quarter_height),
+			RenderTargetProperties::Width(std::nullopt),
+			RenderTargetProperties::Height(std::nullopt),
 			RenderTargetProperties::ExecuteResourceState(ResourceState::UNORDERED_ACCESS),
 			RenderTargetProperties::FinishedResourceState(ResourceState::COPY_SOURCE),
 			RenderTargetProperties::CreateDSVBuffer(false),

--- a/src/render_tasks/d3d12_down_scale.hpp
+++ b/src/render_tasks/d3d12_down_scale.hpp
@@ -152,18 +152,15 @@ namespace wr
 	} /* internal */
 
 	template<typename T, typename T1>
-	inline void AddDownScaleTask(FrameGraph& frame_graph, int32_t width, int32_t height)
+	inline void AddDownScaleTask(FrameGraph& frame_graph)
 	{
-		const std::uint32_t m_half_width = (uint32_t)width / 2;
-		const std::uint32_t m_half_height = (uint32_t)height / 2;
-
 		std::wstring name(L"down scale");
 
 		RenderTargetProperties rt_properties
 		{
 			RenderTargetProperties::IsRenderWindow(false),
-			RenderTargetProperties::Width(m_half_width),
-			RenderTargetProperties::Height(m_half_height),
+			RenderTargetProperties::Width(std::nullopt),
+			RenderTargetProperties::Height(std::nullopt),
 			RenderTargetProperties::ExecuteResourceState(ResourceState::UNORDERED_ACCESS),
 			RenderTargetProperties::FinishedResourceState(ResourceState::COPY_SOURCE),
 			RenderTargetProperties::CreateDSVBuffer(false),

--- a/tests/demo/demo_frame_graphs.hpp
+++ b/tests/demo/demo_frame_graphs.hpp
@@ -95,41 +95,23 @@ namespace fg_manager
 			wr::AddHBAOTask(*fg);
 			wr::AddDeferredCompositionTask(*fg, std::nullopt, std::nullopt);
 
-			//// Do Depth of field task
+			// Do Depth of field task
 			wr::AddDoFCoCTask<wr::DeferredMainTaskData>(*fg);
-
-			wr::AddDownScaleTask<wr::DeferredCompositionTaskData, wr::DoFCoCData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
-			wr::AddDoFDilateTask<wr::DownScaleData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
-			wr::AddDoFDilateFlattenTask<wr::DoFDilateData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
-			wr::AddDoFDilateFlattenHTask<wr::DoFDilateFlattenData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
-			wr::AddDoFBokehTask<wr::DownScaleData, wr::DoFDilateFlattenHData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
-			wr::AddDoFBokehPostFilterTask<wr::DoFBokehData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
+			wr::AddDownScaleTask<wr::DeferredCompositionTaskData, wr::DoFCoCData>(*fg);
+			wr::AddDoFDilateTask<wr::DownScaleData>(*fg);
+			wr::AddDoFDilateFlattenTask<wr::DoFDilateData>(*fg);
+			wr::AddDoFDilateFlattenHTask<wr::DoFDilateFlattenData>(*fg);
+			wr::AddDoFBokehTask<wr::DownScaleData, wr::DoFDilateFlattenHData>(*fg);
+			wr::AddDoFBokehPostFilterTask<wr::DoFBokehData>(*fg);
 			wr::AddDoFCompositionTask<wr::DeferredCompositionTaskData, wr::DoFBokehPostFilterData, wr::DoFCoCData>(*fg);
-
-			wr::AddBloomHorizontalTask<wr::DownScaleData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
-			wr::AddBloomVerticalTask<wr::BloomHData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
+			wr::AddBloomHorizontalTask<wr::DownScaleData>(*fg);
+			wr::AddBloomVerticalTask<wr::BloomHData>(*fg);
 
 			//initialize default settings
 			wr::BloomSettings defaultSettings;
 			fg->UpdateSettings<wr::BloomSettings>(defaultSettings);
 
-			wr::AddBloomCompositionTask<wr::DoFCompositionData, wr::BloomVData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
+			wr::AddBloomCompositionTask<wr::DoFCompositionData, wr::BloomVData>(*fg);
 
 			wr::AddPostProcessingTask<wr::BloomCompostionData>(*fg);
 
@@ -211,39 +193,21 @@ namespace fg_manager
 
 			// Do Depth of field task
 			wr::AddDoFCoCTask<wr::DeferredMainTaskData>(*fg);
-
-			wr::AddDownScaleTask<wr::DeferredCompositionTaskData, wr::DoFCoCData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
-			wr::AddDoFDilateTask<wr::DownScaleData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
-			wr::AddDoFDilateFlattenTask<wr::DoFDilateData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
-			wr::AddDoFDilateFlattenHTask<wr::DoFDilateFlattenData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
-			wr::AddDoFBokehTask<wr::DownScaleData, wr::DoFDilateFlattenHData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
-			wr::AddDoFBokehPostFilterTask<wr::DoFBokehData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
+			wr::AddDownScaleTask<wr::DeferredCompositionTaskData, wr::DoFCoCData>(*fg);
+			wr::AddDoFDilateTask<wr::DownScaleData>(*fg);
+			wr::AddDoFDilateFlattenTask<wr::DoFDilateData>(*fg);
+			wr::AddDoFDilateFlattenHTask<wr::DoFDilateFlattenData>(*fg);
+			wr::AddDoFBokehTask<wr::DownScaleData, wr::DoFDilateFlattenHData>(*fg);
+			wr::AddDoFBokehPostFilterTask<wr::DoFBokehData>(*fg);
 			wr::AddDoFCompositionTask<wr::DeferredCompositionTaskData, wr::DoFBokehPostFilterData, wr::DoFCoCData>(*fg);
-
-			wr::AddBloomHorizontalTask<wr::DownScaleData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
-
-			wr::AddBloomVerticalTask<wr::BloomHData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
+			wr::AddBloomHorizontalTask<wr::DownScaleData>(*fg);
+			wr::AddBloomVerticalTask<wr::BloomHData>(*fg);
 
 			//initialize default settings
 			wr::BloomSettings defaultSettings;
 			fg->UpdateSettings<wr::BloomSettings>(defaultSettings);
 
-			wr::AddBloomCompositionTask<wr::DoFCompositionData, wr::BloomVData>(*fg,
-				rs.m_window.value()->GetWidth(), rs.m_window.value()->GetHeight());
+			wr::AddBloomCompositionTask<wr::DoFCompositionData, wr::BloomVData>(*fg);
 
 			wr::AddPostProcessingTask<wr::BloomCompostionData>(*fg);
 


### PR DESCRIPTION
* No longer have to hardcode initial rendertarget widht and height to render tasks
* Automatically scales rendertargets on startup regardless of resolution

* Small change to current bloom implementation to use a bigger kernel. 