### PR TITLE
Feature uv scaling

### DIFF
--- a/resources/shaders/material_util.hlsl
+++ b/resources/shaders/material_util.hlsl
@@ -58,14 +58,15 @@ OutputMaterialData InterpretMaterialData(MaterialData data,
 	float use_ao_texture = float((data.flags & MATERIAL_HAS_AO_TEXTURE) != 0);
 
 	float4 albedo = lerp(float4(data.color, 1), material_albedo.Sample(s0, uv * data.albedo_uv_scale), use_albedo_texture);
-	//albedo = float4(data.ao_scale, data.ao_scale, data.ao_scale, 1.f);
 
 	float roughness = lerp(data.roughness, max(0.05f, material_roughness.Sample(s0, uv * data.roughness_uv_scale).x), use_roughness_texture);
+
 	float metallic = lerp(data.metallic, material_metallic.Sample(s0, uv * data.metallic_uv_scale).x, use_metallic_texture);
 
 	float3 tex_normal = lerp(float3(0.0f, 0.0f, 1.0f), material_normal.Sample(s0, uv * data.normal_uv_scale).rgb * 2.0f - float3(1.0f, 1.0f, 1.0f), use_normal_texture);
 
 	float3 emissive = lerp(float3(0.0f, 0.0f, 0.0f), material_emissive.Sample(s0, uv * data.emissive_uv_scale).xyz, use_emissive_texture);
+
 	float ao = lerp(1.0f, material_ambient_occlusion.Sample(s0, uv * data.ao_uv_scale).x, use_ao_texture);
 
 	output.albedo = pow(albedo.xyz, 2.2f);

--- a/resources/shaders/material_util.hlsl
+++ b/resources/shaders/material_util.hlsl
@@ -15,7 +15,14 @@ struct MaterialData
 	float is_double_sided;
 	float use_alpha_masking;
 
-	float3 padding;
+	float albedo_uv_scale;
+	float normal_uv_scale;
+	float roughness_uv_scale;
+	float metallic_uv_scale;
+
+	float emissive_uv_scale;
+	float ao_uv_scale;
+	float padding;
 	uint flags;
 };
 
@@ -50,14 +57,16 @@ OutputMaterialData InterpretMaterialData(MaterialData data,
 	float use_emissive_texture = float((data.flags & MATERIAL_HAS_EMISSIVE_TEXTURE) != 0);
 	float use_ao_texture = float((data.flags & MATERIAL_HAS_AO_TEXTURE) != 0);
 
-	float4 albedo = lerp(float4(data.color, 1), material_albedo.Sample(s0, uv), use_albedo_texture);
-	float roughness = lerp(data.roughness, max(0.05f, material_roughness.Sample(s0, uv).x), use_roughness_texture);
-	float metallic = lerp(data.metallic, material_metallic.Sample(s0, uv).x, use_metallic_texture);
+	float4 albedo = lerp(float4(data.color, 1), material_albedo.Sample(s0, uv * data.albedo_uv_scale), use_albedo_texture);
+	//albedo = float4(data.ao_scale, data.ao_scale, data.ao_scale, 1.f);
 
-	float3 tex_normal = lerp(float3(0.0f, 0.0f, 1.0f), material_normal.Sample(s0, uv).rgb * 2.0f - float3(1.0f, 1.0f, 1.0f), use_normal_texture);
+	float roughness = lerp(data.roughness, max(0.05f, material_roughness.Sample(s0, uv * data.roughness_uv_scale).x), use_roughness_texture);
+	float metallic = lerp(data.metallic, material_metallic.Sample(s0, uv * data.metallic_uv_scale).x, use_metallic_texture);
 
-	float3 emissive = lerp(float3(0.0f, 0.0f, 0.0f), material_emissive.Sample(s0, uv).xyz, use_emissive_texture);
-	float ao = lerp(1.0f, material_ambient_occlusion.Sample(s0, uv).x, use_ao_texture);
+	float3 tex_normal = lerp(float3(0.0f, 0.0f, 1.0f), material_normal.Sample(s0, uv * data.normal_uv_scale).rgb * 2.0f - float3(1.0f, 1.0f, 1.0f), use_normal_texture);
+
+	float3 emissive = lerp(float3(0.0f, 0.0f, 0.0f), material_emissive.Sample(s0, uv * data.emissive_uv_scale).xyz, use_emissive_texture);
+	float ao = lerp(1.0f, material_ambient_occlusion.Sample(s0, uv * data.ao_uv_scale).x, use_ao_texture);
 
 	output.albedo = pow(albedo.xyz, 2.2f);
 	output.alpha = albedo.w;
@@ -91,23 +100,26 @@ OutputMaterialData InterpretMaterialDataRT(MaterialData data,
 	float use_ao_texture = float((data.flags & MATERIAL_HAS_AO_TEXTURE) != 0);
 
 	const float4 albedo = lerp(float4(data.color, 1),
-		material_albedo.SampleLevel(s0, uv, mip_level),
+		material_albedo.SampleLevel(s0, uv * (data.albedo_uv_scale * 2), mip_level),
 		use_albedo_texture);
 
 	const float roughness = lerp(data.roughness,
-		max(0.05, material_roughness.SampleLevel(s0, uv, mip_level).r),
+		max(0.05, material_roughness.SampleLevel(s0, uv * data.roughness_uv_scale, mip_level).r),
 		use_roughness_texture);
 
 	const float metallic = lerp(data.metallic,
-		material_metallic.SampleLevel(s0, uv, mip_level).r,
+		material_metallic.SampleLevel(s0, uv * data.metallic_uv_scale, mip_level).r,
 		use_metallic_texture);
 
 	const float3 normal_t = lerp(float3(0.0, 0.0, 1.0),
-		material_normal.SampleLevel(s0, uv, mip_level).xyz * 2 - 1,
+		material_normal.SampleLevel(s0, uv * data.normal_uv_scale, mip_level).xyz * 2 - 1,
 		use_normal_texture);
 
-	float3 emissive = lerp(float3(0.0f, 0.0f, 0.0f), material_emissive.SampleLevel(s0, uv, mip_level).xyz, use_emissive_texture);
-	float ao = lerp(1.0f, material_ambient_occlusion.SampleLevel(s0, uv, mip_level).x, use_ao_texture);
+	float3 emissive = lerp(float3(0.0f, 0.0f, 0.0f), 
+		material_emissive.SampleLevel(s0, uv * data.emissive_uv_scale, mip_level).xyz, use_emissive_texture);
+
+	float ao = lerp(1.0f, 
+		material_ambient_occlusion.SampleLevel(s0, uv * data.ao_uv_scale, mip_level).x, use_ao_texture);
 
 	output.albedo = pow(albedo.xyz, 2.2f);
 	output.alpha = albedo.w;

--- a/resources/shaders/material_util.hlsl
+++ b/resources/shaders/material_util.hlsl
@@ -101,7 +101,7 @@ OutputMaterialData InterpretMaterialDataRT(MaterialData data,
 	float use_ao_texture = float((data.flags & MATERIAL_HAS_AO_TEXTURE) != 0);
 
 	const float4 albedo = lerp(float4(data.color, 1),
-		material_albedo.SampleLevel(s0, uv * (data.albedo_uv_scale * 2), mip_level),
+		material_albedo.SampleLevel(s0, uv * (data.albedo_uv_scale), mip_level),
 		use_albedo_texture);
 
 	const float roughness = lerp(data.roughness,

--- a/src/d3d12/d3d12_renderer.hpp
+++ b/src/d3d12/d3d12_renderer.hpp
@@ -71,15 +71,8 @@ namespace wr
 			std::uint32_t metallicness_id;
 			std::uint32_t emissive_id;
 			std::uint32_t ao_id;
-			float albedo_scale;
-			float normal_scale;
-			float roughness_scale;
-			float metallic_scale;
 
-			float emissive_scale;
-			float ao_scale;
-
-			uint32_t m_padding;
+			DirectX::XMFLOAT2 padding;
 			Material::MaterialData material_data;
 		};
 

--- a/src/d3d12/d3d12_renderer.hpp
+++ b/src/d3d12/d3d12_renderer.hpp
@@ -71,8 +71,15 @@ namespace wr
 			std::uint32_t metallicness_id;
 			std::uint32_t emissive_id;
 			std::uint32_t ao_id;
-			DirectX::XMFLOAT2 padding;
+			float albedo_scale;
+			float normal_scale;
+			float roughness_scale;
+			float metallic_scale;
 
+			float emissive_scale;
+			float ao_scale;
+
+			uint32_t m_padding;
 			Material::MaterialData material_data;
 		};
 

--- a/src/material_pool.cpp
+++ b/src/material_pool.cpp
@@ -17,6 +17,12 @@ namespace wr
 		memset(&m_material_data, 0, sizeof(m_material_data));
 
 		SetConstant<MaterialConstant::EMISSIVE_MULTIPLIER>(1.0f);
+		SetConstant<MaterialConstant::ALBEDO_UV_SCALE>(1.0f);
+		SetConstant<MaterialConstant::NORMAL_UV_SCALE>(1.0f);
+		SetConstant<MaterialConstant::ROUGHNESS_UV_SCALE>(1.0f);
+		SetConstant<MaterialConstant::METALLIC_UV_SCALE>(1.0f);
+		SetConstant<MaterialConstant::EMISSIVE_UV_SCALE>(1.0f);
+		SetConstant<MaterialConstant::AO_UV_SCALE>(1.0f);
 	}
 
 	Material::Material(TexturePool *pool,
@@ -26,6 +32,7 @@ namespace wr
 					   TextureHandle metallic,
 					   TextureHandle emissive,
 		               TextureHandle ao,
+					   MaterialUVScales scales,
 		               bool alpha_masked,
 					   bool double_sided): Material(pool)
 	{
@@ -36,6 +43,13 @@ namespace wr
 		SetTexture(TextureType::METALLIC, metallic);
 		SetTexture(TextureType::EMISSIVE, emissive);
 		SetTexture(TextureType::AO, ao);
+
+		m_material_data.albedo_scale = scales.m_albedo_scale;
+		m_material_data.normal_scale = scales.m_normal_scale;
+		m_material_data.roughness_scale = scales.m_roughness_scale;
+		m_material_data.metallic_scale = scales.m_metallic_scale;
+		m_material_data.emissive_scale = scales.m_emissive_scale;
+		m_material_data.ao_scale = scales.m_ao_scale;
 
 		SetConstant<MaterialConstant::IS_ALPHA_MASKED>(alpha_masked);
 		SetConstant<MaterialConstant::IS_DOUBLE_SIDED>(double_sided);
@@ -109,13 +123,13 @@ namespace wr
 
 	MaterialHandle MaterialPool::Create(TexturePool* pool, TextureHandle& albedo, TextureHandle& normal,
 										TextureHandle& roughness, TextureHandle& metallic, TextureHandle& emissive,
-										TextureHandle& ao, bool is_alpha_masked, bool is_double_sided)
+										TextureHandle& ao, MaterialUVScales& mat_scales, bool is_alpha_masked, bool is_double_sided)
 	{
 		MaterialHandle handle = {};
 		handle.m_pool = this;
 		handle.m_id = m_id_factory.GetUnusedID();
 
-		Material* mat = new Material(pool, albedo, normal, roughness, metallic, emissive, ao, is_alpha_masked, is_double_sided);
+		Material* mat = new Material(pool, albedo, normal, roughness, metallic, emissive, ao, mat_scales, is_alpha_masked, is_double_sided);
 		mat->SetConstantBufferHandle(m_constant_buffer_pool->Create(sizeof(Material::MaterialData)));
 		mat->UpdateConstantBuffer();
 

--- a/src/material_pool.cpp
+++ b/src/material_pool.cpp
@@ -17,12 +17,12 @@ namespace wr
 		memset(&m_material_data, 0, sizeof(m_material_data));
 
 		SetConstant<MaterialConstant::EMISSIVE_MULTIPLIER>(1.0f);
-		SetConstant<MaterialConstant::ALBEDO_UV_SCALE>(4.0f);
-		SetConstant<MaterialConstant::NORMAL_UV_SCALE>(4.0f);
-		SetConstant<MaterialConstant::ROUGHNESS_UV_SCALE>(4.0f);
-		SetConstant<MaterialConstant::METALLIC_UV_SCALE>(4.0f);
-		SetConstant<MaterialConstant::EMISSIVE_UV_SCALE>(4.0f);
-		SetConstant<MaterialConstant::AO_UV_SCALE>(4.0f);
+		SetConstant<MaterialConstant::ALBEDO_UV_SCALE>(1.0f);
+		SetConstant<MaterialConstant::NORMAL_UV_SCALE>(1.0f);
+		SetConstant<MaterialConstant::ROUGHNESS_UV_SCALE>(1.0f);
+		SetConstant<MaterialConstant::METALLIC_UV_SCALE>(1.0f);
+		SetConstant<MaterialConstant::EMISSIVE_UV_SCALE>(1.0f);
+		SetConstant<MaterialConstant::AO_UV_SCALE>(1.0f);
 	}
 
 	Material::Material(TexturePool *pool,

--- a/src/material_pool.cpp
+++ b/src/material_pool.cpp
@@ -17,12 +17,12 @@ namespace wr
 		memset(&m_material_data, 0, sizeof(m_material_data));
 
 		SetConstant<MaterialConstant::EMISSIVE_MULTIPLIER>(1.0f);
-		SetConstant<MaterialConstant::ALBEDO_UV_SCALE>(1.0f);
-		SetConstant<MaterialConstant::NORMAL_UV_SCALE>(1.0f);
-		SetConstant<MaterialConstant::ROUGHNESS_UV_SCALE>(1.0f);
-		SetConstant<MaterialConstant::METALLIC_UV_SCALE>(1.0f);
-		SetConstant<MaterialConstant::EMISSIVE_UV_SCALE>(1.0f);
-		SetConstant<MaterialConstant::AO_UV_SCALE>(1.0f);
+		SetConstant<MaterialConstant::ALBEDO_UV_SCALE>(4.0f);
+		SetConstant<MaterialConstant::NORMAL_UV_SCALE>(4.0f);
+		SetConstant<MaterialConstant::ROUGHNESS_UV_SCALE>(4.0f);
+		SetConstant<MaterialConstant::METALLIC_UV_SCALE>(4.0f);
+		SetConstant<MaterialConstant::EMISSIVE_UV_SCALE>(4.0f);
+		SetConstant<MaterialConstant::AO_UV_SCALE>(4.0f);
 	}
 
 	Material::Material(TexturePool *pool,
@@ -51,6 +51,12 @@ namespace wr
 		m_material_data.emissive_scale = scales.m_emissive_scale;
 		m_material_data.ao_scale = scales.m_ao_scale;
 
+		SetConstant<MaterialConstant::ALBEDO_UV_SCALE>(scales.m_albedo_scale);
+		SetConstant<MaterialConstant::NORMAL_UV_SCALE>(scales.m_normal_scale);
+		SetConstant<MaterialConstant::ROUGHNESS_UV_SCALE>(scales.m_roughness_scale);
+		SetConstant<MaterialConstant::METALLIC_UV_SCALE>(scales.m_metallic_scale);
+		SetConstant<MaterialConstant::EMISSIVE_UV_SCALE>(scales.m_emissive_scale);
+		SetConstant<MaterialConstant::AO_UV_SCALE>(scales.m_ao_scale);
 		SetConstant<MaterialConstant::IS_ALPHA_MASKED>(alpha_masked);
 		SetConstant<MaterialConstant::IS_DOUBLE_SIDED>(double_sided);
 		SetConstant<MaterialConstant::EMISSIVE_MULTIPLIER>(1.0f);

--- a/src/material_pool.hpp
+++ b/src/material_pool.hpp
@@ -43,7 +43,13 @@ namespace wr
 		EMISSIVE_MULTIPLIER = (5 << 16) | 0,
 		IS_DOUBLE_SIDED = (6 << 16) | 0,
 		IS_ALPHA_MASKED = (7 << 16) | 0,
-		MAX_OFFSET = 8
+		ALBEDO_UV_SCALE = (8 << 16) | 0,
+		NORMAL_UV_SCALE = (9 << 16) | 0,
+		ROUGHNESS_UV_SCALE = (10 << 16) | 0,
+		METALLIC_UV_SCALE = (11 << 16) | 0,
+		EMISSIVE_UV_SCALE = (12 << 16) | 0,
+		AO_UV_SCALE = (13 << 16) | 0,
+		MAX_OFFSET = 14
 	};
 
 	class Material
@@ -58,6 +64,7 @@ namespace wr
 				 TextureHandle metallic,
 				 TextureHandle emissive,
 				 TextureHandle ao, 
+				 MaterialUVScales mat_scales,
 				 bool alpha_masked = false,
 				 bool double_sided = false);
 
@@ -127,12 +134,19 @@ namespace wr
 				float m_is_double_sided;
 				float m_use_alpha_constant;
 
-				float m_padding[3];
+				float albedo_scale;
+				float normal_scale;
+				float roughness_scale;
+				float metallic_scale;
+
+				float emissive_scale;
+				float ao_scale;
+				float m_padding;
 				TextureFlags m_material_flags;
 
 			};
 
-			float m_constant_data[size_t(MaterialConstant::MAX_OFFSET) + 1]{};
+			float m_constant_data[size_t(MaterialConstant::MAX_OFFSET)]{};
 
 		};
 
@@ -182,7 +196,8 @@ namespace wr
 											TextureHandle& roughness,
 											TextureHandle& metallic,
 											TextureHandle& emissive,
-											TextureHandle& ao, 
+											TextureHandle& ao,
+											MaterialUVScales& mat_scales,
 											bool is_alpha_masked = false, 
 											bool is_double_sided = false);
 

--- a/src/model_pool.hpp
+++ b/src/model_pool.hpp
@@ -315,7 +315,12 @@ namespace wr
 				}
 			};
 
-			auto new_handle = material_pool->Create(texture_pool, albedo, normals, roughness, metallic, emissive, ambient_occlusion, false, true);
+			//TODO: Maya team integrate texture scales in loading
+			// Currently default scales are set to 1 for all materials.
+			MaterialUVScales default_scales;
+
+
+			auto new_handle = material_pool->Create(texture_pool, albedo, normals, roughness, metallic, emissive, ambient_occlusion, default_scales, false, true);
 			Material* mat = material_pool->GetMaterial(new_handle);
 
 			if (material->m_albedo_texture_location!=TextureLocation::NON_EXISTENT)

--- a/src/structs.hpp
+++ b/src/structs.hpp
@@ -19,7 +19,7 @@ namespace wr
 
 	struct MaterialUVScales
 	{
-		float m_albedo_scale = 1.0f
+		float m_albedo_scale = 1.0f;
 		float m_normal_scale = 1.0f;
 		float m_roughness_scale = 1.0f;
 		float m_metallic_scale = 1.0f;

--- a/src/structs.hpp
+++ b/src/structs.hpp
@@ -19,12 +19,12 @@ namespace wr
 
 	struct MaterialUVScales
 	{
-		float m_albedo_scale = 2;
-		float m_normal_scale = 2;
-		float m_roughness_scale = 2;
-		float m_metallic_scale = 2;
-		float m_emissive_scale = 2;
-		float m_ao_scale = 2;
+		float m_albedo_scale = 1.f
+		float m_normal_scale = 1.f;
+		float m_roughness_scale = 1.f;
+		float m_metallic_scale = 1.f;
+		float m_emissive_scale = 1.f;
+		float m_ao_scale = 1.f;
 	};
 
 	struct CPUTexture

--- a/src/structs.hpp
+++ b/src/structs.hpp
@@ -19,12 +19,12 @@ namespace wr
 
 	struct MaterialUVScales
 	{
-		float m_albedo_scale = 1.f
-		float m_normal_scale = 1.f;
-		float m_roughness_scale = 1.f;
-		float m_metallic_scale = 1.f;
-		float m_emissive_scale = 1.f;
-		float m_ao_scale = 1.f;
+		float m_albedo_scale = 1.0f
+		float m_normal_scale = 1.0f;
+		float m_roughness_scale = 1.0f;
+		float m_metallic_scale = 1.0f;
+		float m_emissive_scale = 1.0f;
+		float m_ao_scale = 1.0f;
 	};
 
 	struct CPUTexture

--- a/src/structs.hpp
+++ b/src/structs.hpp
@@ -16,6 +16,16 @@ namespace wr
 		std::uint32_t m_id = 0;
 	};
 
+	struct MaterialUVScales
+	{
+		float m_albedo_scale = 2;
+		float m_normal_scale = 2;
+		float m_roughness_scale = 2;
+		float m_metallic_scale = 2;
+		float m_emissive_scale = 2;
+		float m_ao_scale = 2;
+	};
+
 	struct CPUTexture
 	{
 		float* m_data = nullptr;


### PR DESCRIPTION
* Scales the material's UV's of the following individually
- Albedo
- Normal
- Roughness
- Metallic
- Emissive
- AO 

SetConstants should be called from maya to set scales, Materials can be created by passing in the extra struct "MaterialUVScales".

Works on both deferred and raytracing.