### PR TITLE
Fixed Maya crashes

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -204,7 +204,6 @@ namespace wr
 			return 0;
 		case WM_DESTROY:
 			m_running = false;
-			PostQuitMessage(0);
 			return 0;
 		case WM_LBUTTONDOWN:
 		case WM_LBUTTONUP:


### PR DESCRIPTION
Maya crashes when this function is used. Usually, it's the best way to shut-down a window, but it is not the best way to do it this time. It sends the main window a shut-down message (a.k.a. Maya), which resulted in the weird crashes we've been experiencing since block B.