### PR TITLE
Feature successful maya compilation

### DIFF
--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -73,8 +73,6 @@ namespace wr
 
 	void D3D12RenderSystem::Init(std::optional<Window*> window)
 	{
-		TRY_M(CoInitializeEx(nullptr, COINITBASE_MULTITHREADED), "Failed to CoInitialize");
-
 		m_window = window;
 		m_device = d3d12::CreateDevice();
 		SetName(m_device, L"Default D3D12 Device");

--- a/src/frame_graph/frame_graph.hpp
+++ b/src/frame_graph/frame_graph.hpp
@@ -907,7 +907,7 @@ namespace wr
 		}
 
 		/*! Get a free unique ID. */
-		WISPRENDERER_EXPORT static std::uint64_t GetFreeUID()
+		static std::uint64_t GetFreeUID()
 		{
 			if (!m_free_uids.empty())
 			{


### PR DESCRIPTION
This PR attempts to make life easier for the Maya feature team.
Wisp recently introduced some features that cause the Maya project to either fail to compile or enter a crashing state at runtime.