### PR TITLE
Fix reduce warnings

### DIFF
--- a/src/d3d12/d3d12_acceleration_structure..cpp
+++ b/src/d3d12/d3d12_acceleration_structure..cpp
@@ -112,7 +112,7 @@ namespace wr::d3d12
 			if (!(as.m_prebuild_info.ResultDataMaxSizeInBytes > 0)) LOGW("Result data max size in bytes is more than zero. accel structure");
 		}
 
-		inline void BuildAS(Device* device, CommandList* cmd_list, DescriptorHeap* desc_heap, AccelerationStructure& as, D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC const & desc)
+		inline void BuildAS(Device* device, CommandList* cmd_list, DescriptorHeap* desc_heap, D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC const & desc)
 		{
 			auto BuildAccelerationStructure = [&](auto * raytracingCommandList)
 			{
@@ -308,7 +308,7 @@ namespace wr::d3d12
 			bottom_level_build_desc.DestAccelerationStructureData = blas.m_natives[0]->GetGPUVirtualAddress();
 		}
 
-		internal::BuildAS(device, cmd_list, desc_heap, blas, bottom_level_build_desc);
+		internal::BuildAS(device, cmd_list, desc_heap, bottom_level_build_desc);
 		d3d12::UAVBarrierAS(cmd_list, blas, 0);
 
 		for (std::uint8_t i = 1; i < settings::num_back_buffers; i++)
@@ -368,7 +368,7 @@ namespace wr::d3d12
 			top_level_build_desc.ScratchAccelerationStructureData = tlas.m_scratch->GetGPUVirtualAddress();
 		}
 
-		internal::BuildAS(device, cmd_list, desc_heap, tlas, top_level_build_desc);
+		internal::BuildAS(device, cmd_list, desc_heap, top_level_build_desc);
 
 		d3d12::UAVBarrierAS(cmd_list, tlas, 0);
 		for (std::uint8_t i = 1; i < settings::num_back_buffers; i++)
@@ -446,7 +446,7 @@ namespace wr::d3d12
 				top_level_build_desc.ScratchAccelerationStructureData = tlas.m_scratch->GetGPUVirtualAddress();
 			}
 
-			internal::BuildAS(device, cmd_list, desc_heap, tlas, top_level_build_desc);
+			internal::BuildAS(device, cmd_list, desc_heap, top_level_build_desc);
 		}
 	}
 

--- a/src/d3d12/d3d12_command_list.cpp
+++ b/src/d3d12/d3d12_command_list.cpp
@@ -270,7 +270,7 @@ namespace wr::d3d12
 		cmd_list->m_native->IASetVertexBuffers(0, 1, &view);
 	}
 
-	void BindIndexBuffer(CommandList* cmd_list, StagingBuffer* buffer, std::size_t offset, std::size_t size)
+	void BindIndexBuffer(CommandList* cmd_list, StagingBuffer* buffer, std::uint32_t offset, std::uint32_t size)
 	{
 		if (!buffer->m_gpu_address)
 		{
@@ -280,7 +280,7 @@ namespace wr::d3d12
 		D3D12_INDEX_BUFFER_VIEW view;
 		view.BufferLocation = buffer->m_gpu_address + offset;
 		view.Format = DXGI_FORMAT_R32_UINT;
-		view.SizeInBytes = static_cast<UINT>(size);
+		view.SizeInBytes = size;
 
 		cmd_list->m_native->IASetIndexBuffer(&view);
 	}

--- a/src/d3d12/d3d12_command_list.cpp
+++ b/src/d3d12/d3d12_command_list.cpp
@@ -113,7 +113,11 @@ namespace wr::d3d12
 		}
 
 		CD3DX12_CPU_DESCRIPTOR_HANDLE dsv_handle;
-		if (render_target->m_create_info.m_create_dsv_buffer) dsv_handle = render_target->m_depth_stencil_resource_heap->GetCPUDescriptorHandleForHeapStart();
+
+		if (render_target->m_create_info.m_create_dsv_buffer)
+		{
+			dsv_handle = render_target->m_depth_stencil_resource_heap->GetCPUDescriptorHandleForHeapStart();
+		}
 
 		cmd_list->m_native->OMSetRenderTargets(static_cast<unsigned int>(handles.size()), handles.data(), false, render_target->m_create_info.m_create_dsv_buffer ? &dsv_handle : nullptr);
 		if (clear)
@@ -133,8 +137,13 @@ namespace wr::d3d12
 	{
 		CD3DX12_CPU_DESCRIPTOR_HANDLE rtv_handle(render_target->m_rtv_descriptor_heap->GetCPUDescriptorHandleForHeapStart(),
 			frame_idx % render_target->m_render_targets.size(), render_target->m_rtv_descriptor_increment_size);
+
 		CD3DX12_CPU_DESCRIPTOR_HANDLE dsv_handle;
-		if (render_target->m_create_info.m_create_dsv_buffer) dsv_handle = render_target->m_depth_stencil_resource_heap->GetCPUDescriptorHandleForHeapStart();
+
+		if (render_target->m_create_info.m_create_dsv_buffer)
+		{
+			dsv_handle = render_target->m_depth_stencil_resource_heap->GetCPUDescriptorHandleForHeapStart();
+		}
 
 		cmd_list->m_native->OMSetRenderTargets(1, &rtv_handle, false, render_target->m_create_info.m_create_dsv_buffer ? &dsv_handle : nullptr);
 
@@ -142,6 +151,7 @@ namespace wr::d3d12
 		{
 			cmd_list->m_native->ClearRenderTargetView(rtv_handle, render_target->m_create_info.m_clear_color, 0, nullptr);
 		}
+
 		if (clear_depth && render_target->m_create_info.m_create_dsv_buffer)
 		{
 			cmd_list->m_native->ClearDepthStencilView(dsv_handle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
@@ -151,7 +161,11 @@ namespace wr::d3d12
 	void BindRenderTargetOnlyDepth(CommandList* cmd_list, RenderTarget* render_target, bool clear)
 	{
 		CD3DX12_CPU_DESCRIPTOR_HANDLE dsv_handle;
-		if (render_target->m_create_info.m_create_dsv_buffer) dsv_handle = render_target->m_depth_stencil_resource_heap->GetCPUDescriptorHandleForHeapStart();
+
+		if (render_target->m_create_info.m_create_dsv_buffer)
+		{
+			dsv_handle = render_target->m_depth_stencil_resource_heap->GetCPUDescriptorHandleForHeapStart();
+		}
 
 		cmd_list->m_native->OMSetRenderTargets(0, nullptr, false, render_target->m_create_info.m_create_dsv_buffer ? &dsv_handle : nullptr);
 
@@ -256,7 +270,7 @@ namespace wr::d3d12
 		cmd_list->m_native->IASetVertexBuffers(0, 1, &view);
 	}
 
-	void BindIndexBuffer(CommandList* cmd_list, StagingBuffer* buffer, unsigned int offset, unsigned int size)
+	void BindIndexBuffer(CommandList* cmd_list, StagingBuffer* buffer, std::size_t offset, std::size_t size)
 	{
 		if (!buffer->m_gpu_address)
 		{
@@ -266,7 +280,7 @@ namespace wr::d3d12
 		D3D12_INDEX_BUFFER_VIEW view;
 		view.BufferLocation = buffer->m_gpu_address + offset;
 		view.Format = DXGI_FORMAT_R32_UINT;
-		view.SizeInBytes = size;
+		view.SizeInBytes = static_cast<UINT>(size);
 
 		cmd_list->m_native->IASetIndexBuffer(&view);
 	}

--- a/src/d3d12/d3d12_command_list.cpp
+++ b/src/d3d12/d3d12_command_list.cpp
@@ -250,8 +250,8 @@ namespace wr::d3d12
 
 		D3D12_VERTEX_BUFFER_VIEW view;
 		view.BufferLocation = buffer->m_gpu_address + offset;
-		view.StrideInBytes = stride;
-		view.SizeInBytes = size;
+		view.StrideInBytes = static_cast<UINT>(stride);
+		view.SizeInBytes = static_cast<UINT>(size);
 
 		cmd_list->m_native->IASetVertexBuffers(0, 1, &view);
 	}

--- a/src/d3d12/d3d12_descriptor_heap.cpp
+++ b/src/d3d12/d3d12_descriptor_heap.cpp
@@ -68,12 +68,12 @@ namespace wr::d3d12
 
 	void Offset(DescHeapGPUHandle& handle, unsigned int index, unsigned int increment_size)
 	{
-		handle.m_native.ptr += index * increment_size;
+		handle.m_native.ptr += static_cast<UINT64>(index) * static_cast<UINT64>(increment_size);
 	}
 
 	void Offset(DescHeapCPUHandle& handle, unsigned int index, unsigned int increment_size)
 	{
-		handle.m_native.ptr += index * increment_size;
+		handle.m_native.ptr += static_cast<UINT64>(index) * static_cast<UINT64>(increment_size);
 	}
 
 	void Destroy(DescriptorHeap* desc_heap)

--- a/src/d3d12/d3d12_functions.hpp
+++ b/src/d3d12/d3d12_functions.hpp
@@ -54,7 +54,7 @@ namespace wr::d3d12
 	void BindComputeDescriptorTable(CommandList* cmd_list, DescHeapGPUHandle& handle, unsigned int root_param_index);
 	//void Bind(CommandList& cmd_list, std::vector<DescriptorHeap*> const & heaps);
 	void BindVertexBuffer(CommandList* cmd_list, StagingBuffer* buffer, std::size_t offset, std::size_t size, std::size_t m_stride);
-	void BindIndexBuffer(CommandList* cmd_list, StagingBuffer* buffer, unsigned int offset, unsigned int size);
+	void BindIndexBuffer(CommandList* cmd_list, StagingBuffer* buffer, std::size_t offset, std::size_t size);
 	void Draw(CommandList* cmd_list, std::uint32_t vertex_count, std::uint32_t inst_count, std::uint32_t vertex_start);
 	void DrawIndexed(CommandList* cmd_list, std::uint32_t idx_count, std::uint32_t inst_count, std::uint32_t idx_start, std::uint32_t vertex_start);
 	void Dispatch(CommandList* cmd_list, unsigned int thread_group_count_x, unsigned int thread_group_count_y, unsigned int thread_group_count_z);

--- a/src/d3d12/d3d12_functions.hpp
+++ b/src/d3d12/d3d12_functions.hpp
@@ -54,7 +54,7 @@ namespace wr::d3d12
 	void BindComputeDescriptorTable(CommandList* cmd_list, DescHeapGPUHandle& handle, unsigned int root_param_index);
 	//void Bind(CommandList& cmd_list, std::vector<DescriptorHeap*> const & heaps);
 	void BindVertexBuffer(CommandList* cmd_list, StagingBuffer* buffer, std::size_t offset, std::size_t size, std::size_t m_stride);
-	void BindIndexBuffer(CommandList* cmd_list, StagingBuffer* buffer, std::size_t offset, std::size_t size);
+	void BindIndexBuffer(CommandList* cmd_list, StagingBuffer* buffer, std::uint32_t offset, std::uint32_t size);
 	void Draw(CommandList* cmd_list, std::uint32_t vertex_count, std::uint32_t inst_count, std::uint32_t vertex_start);
 	void DrawIndexed(CommandList* cmd_list, std::uint32_t idx_count, std::uint32_t inst_count, std::uint32_t idx_start, std::uint32_t vertex_start);
 	void Dispatch(CommandList* cmd_list, unsigned int thread_group_count_x, unsigned int thread_group_count_y, unsigned int thread_group_count_z);

--- a/src/d3d12/d3d12_heap.cpp
+++ b/src/d3d12/d3d12_heap.cpp
@@ -886,10 +886,11 @@ namespace wr::d3d12
 		if (size_in_bytes != 0) {
 			ID3D12Resource* resource = buffer->m_heap_bsbo->m_resources[buffer->m_heap_vector_location].second[frame_idx];
 
-			cmd_list->m_native->ResourceBarrier(1,
-				&CD3DX12_RESOURCE_BARRIER::Transition(resource,
-					static_cast<D3D12_RESOURCE_STATES>(buffer->m_states[frame_idx]),
-					D3D12_RESOURCE_STATE_COPY_DEST));
+			CD3DX12_RESOURCE_BARRIER resource_barrier = CD3DX12_RESOURCE_BARRIER::Transition(resource,
+				static_cast<D3D12_RESOURCE_STATES>(buffer->m_states[frame_idx]),
+				D3D12_RESOURCE_STATE_COPY_DEST);
+
+			cmd_list->m_native->ResourceBarrier(1, &resource_barrier);
 			
 			cmd_list->m_native->CopyBufferRegion(resource, 
 				offset, 
@@ -897,11 +898,12 @@ namespace wr::d3d12
 				buffer->m_begin_offset + offset + aligned_size * frame_idx, 
 				size_in_bytes);
 
-			
+			CD3DX12_RESOURCE_BARRIER copy_barrier = CD3DX12_RESOURCE_BARRIER::Transition(resource,
+				D3D12_RESOURCE_STATE_COPY_DEST,
+				static_cast<D3D12_RESOURCE_STATES>(buffer->m_states[frame_idx]));
+
 			cmd_list->m_native->ResourceBarrier(1,
-				&CD3DX12_RESOURCE_BARRIER::Transition(resource,
-					D3D12_RESOURCE_STATE_COPY_DEST,
-					static_cast<D3D12_RESOURCE_STATES>(buffer->m_states[frame_idx])));
+				&copy_barrier);
 		}
 	}
 

--- a/src/d3d12/d3d12_heap.cpp
+++ b/src/d3d12/d3d12_heap.cpp
@@ -36,7 +36,7 @@ namespace wr::d3d12
 		};
 	}
 
-	Heap<HeapOptimization::SMALL_BUFFERS>* CreateHeap_SBO(Device* device, std::uint64_t size_in_bytes, ResourceType resource_type, unsigned int versioning_count)
+	Heap<HeapOptimization::SMALL_BUFFERS>* CreateHeap_SBO(Device* device, std::uint64_t size_in_bytes, ResourceType resource , unsigned int versioning_count)
 	{
 		auto heap = new Heap<HeapOptimization::SMALL_BUFFERS>();
 		heap->m_mapped = false;
@@ -118,7 +118,7 @@ namespace wr::d3d12
 		return heap;
 	}
 
-	Heap<HeapOptimization::SMALL_STATIC_BUFFERS>* CreateHeap_SSBO(Device * device, std::uint64_t size_in_bytes, ResourceType resource_type, unsigned int versioning_count)
+	Heap<HeapOptimization::SMALL_STATIC_BUFFERS>* CreateHeap_SSBO(Device * device, std::uint64_t size_in_bytes, unsigned int versioning_count)
 	{
 		auto heap = new Heap<HeapOptimization::SMALL_STATIC_BUFFERS>();
 		heap->m_mapped = false;

--- a/src/d3d12/d3d12_indirect_command_buffer.cpp
+++ b/src/d3d12/d3d12_indirect_command_buffer.cpp
@@ -17,20 +17,25 @@ namespace wr::d3d12
 		buffer->m_native.resize(versions);
 		buffer->m_native_upload.resize(versions);
 
+		CD3DX12_HEAP_PROPERTIES heap_properties_default = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+		CD3DX12_HEAP_PROPERTIES heap_properties_upload = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+		CD3DX12_RESOURCE_DESC buffer_desc = CD3DX12_RESOURCE_DESC::Buffer(max_commands * command_size);
+
 		for (uint32_t i = 0; i < versions; ++i)
 		{
+
 			TRY(device->m_native->CreateCommittedResource(
-				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				&heap_properties_default,
 				D3D12_HEAP_FLAG_NONE,
-				&CD3DX12_RESOURCE_DESC::Buffer(max_commands * command_size),
+				&buffer_desc,
 				D3D12_RESOURCE_STATE_INDIRECT_ARGUMENT,
 				nullptr,
 				IID_PPV_ARGS(buffer->m_native.data() + i)));
 
 			TRY(device->m_native->CreateCommittedResource(
-				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				&heap_properties_upload,
 				D3D12_HEAP_FLAG_NONE,
-				&CD3DX12_RESOURCE_DESC::Buffer(max_commands * command_size),
+				&buffer_desc,
 				D3D12_RESOURCE_STATE_GENERIC_READ,
 				nullptr,
 				IID_PPV_ARGS(buffer->m_native_upload.data() + i)));

--- a/src/d3d12/d3d12_model_pool.cpp
+++ b/src/d3d12/d3d12_model_pool.cpp
@@ -125,10 +125,11 @@ namespace wr
 			{
 				internal::TransitionCommand* transition_command = static_cast<internal::TransitionCommand*>(command);
 
-				cmd_list->m_native->ResourceBarrier(1, 
-					&CD3DX12_RESOURCE_BARRIER::Transition(transition_command->m_buffer, 
-						static_cast<D3D12_RESOURCE_STATES>(transition_command->m_old_state), 
-						static_cast<D3D12_RESOURCE_STATES>(transition_command->m_new_state)));
+				CD3DX12_RESOURCE_BARRIER barrier = CD3DX12_RESOURCE_BARRIER::Transition(transition_command->m_buffer,
+					static_cast<D3D12_RESOURCE_STATES>(transition_command->m_old_state),
+					static_cast<D3D12_RESOURCE_STATES>(transition_command->m_new_state));
+
+				cmd_list->m_native->ResourceBarrier(1, &barrier);
 
 				delete transition_command;
 				m_command_queue.pop();
@@ -205,10 +206,14 @@ namespace wr
 
 		uint8_t* cpu_address;
 
+		CD3DX12_HEAP_PROPERTIES heap_properties_default = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+		CD3DX12_HEAP_PROPERTIES heap_properties_upload = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+		CD3DX12_RESOURCE_DESC buffer_desc = CD3DX12_RESOURCE_DESC::Buffer(new_size);
+
 		m_render_system.m_device->m_native->CreateCommittedResource(
-			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			&heap_properties_upload,
 			D3D12_HEAP_FLAG_NONE,
-			&CD3DX12_RESOURCE_DESC::Buffer(new_size),
+			&buffer_desc,
 			D3D12_RESOURCE_STATE_GENERIC_READ,
 			nullptr,
 			IID_PPV_ARGS(&new_staging));
@@ -230,9 +235,9 @@ namespace wr
 		SAFE_RELEASE(m_vertex_buffer->m_staging);
 
 		m_render_system.m_device->m_native->CreateCommittedResource(
-			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			&heap_properties_default,
 			D3D12_HEAP_FLAG_NONE,
-			&CD3DX12_RESOURCE_DESC::Buffer(new_size),
+			&buffer_desc,
 			static_cast<D3D12_RESOURCE_STATES>(m_vertex_buffer->m_target_resource_state),
 			nullptr,
 			IID_PPV_ARGS(&new_buffer));
@@ -359,10 +364,14 @@ namespace wr
 
 		uint8_t* cpu_address;
 
+		CD3DX12_HEAP_PROPERTIES heap_properties_default = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+		CD3DX12_HEAP_PROPERTIES heap_properties_upload = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+		CD3DX12_RESOURCE_DESC buffer_desc = CD3DX12_RESOURCE_DESC::Buffer(new_size);
+
 		m_render_system.m_device->m_native->CreateCommittedResource(
-			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+			&heap_properties_upload,
 			D3D12_HEAP_FLAG_NONE,
-			&CD3DX12_RESOURCE_DESC::Buffer(new_size),
+			&buffer_desc,
 			D3D12_RESOURCE_STATE_GENERIC_READ,
 			nullptr,
 			IID_PPV_ARGS(&new_staging));
@@ -384,9 +393,9 @@ namespace wr
 		SAFE_RELEASE(m_index_buffer->m_staging);
 
 		m_render_system.m_device->m_native->CreateCommittedResource(
-			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			&heap_properties_default,
 			D3D12_HEAP_FLAG_NONE,
-			&CD3DX12_RESOURCE_DESC::Buffer(new_size),
+			&buffer_desc,
 			static_cast<D3D12_RESOURCE_STATES>(m_index_buffer->m_target_resource_state),
 			nullptr,
 			IID_PPV_ARGS(&new_buffer));
@@ -529,10 +538,13 @@ namespace wr
 			if (largest_block->m_size > m_intermediate_size)
 			{
 				ID3D12Resource* buffer;
+				CD3DX12_HEAP_PROPERTIES heap_properties_default = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+				CD3DX12_RESOURCE_DESC buffer_desc = CD3DX12_RESOURCE_DESC::Buffer(SizeAlignAnyAlignment(largest_block->m_size, 65536));
+
 				m_render_system.m_device->m_native->CreateCommittedResource(
-					&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+					&heap_properties_default,
 					D3D12_HEAP_FLAG_NONE,
-					&CD3DX12_RESOURCE_DESC::Buffer(SizeAlignAnyAlignment(largest_block->m_size, 65536)),
+					&buffer_desc,
 					D3D12_RESOURCE_STATE_COPY_DEST,
 					nullptr,
 					IID_PPV_ARGS(&buffer));
@@ -787,10 +799,13 @@ namespace wr
 			if (largest_block->m_size > m_intermediate_size)
 			{
 				ID3D12Resource* buffer;
+				CD3DX12_HEAP_PROPERTIES heap_properties_default = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+				CD3DX12_RESOURCE_DESC buffer_desc = CD3DX12_RESOURCE_DESC::Buffer(SizeAlignAnyAlignment(largest_block->m_size, 65536));
+
 				m_render_system.m_device->m_native->CreateCommittedResource(
-					&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+					&heap_properties_default,
 					D3D12_HEAP_FLAG_NONE,
-					&CD3DX12_RESOURCE_DESC::Buffer(SizeAlignAnyAlignment(largest_block->m_size, 65536)),
+					&buffer_desc,
 					D3D12_RESOURCE_STATE_COPY_DEST,
 					nullptr,
 					IID_PPV_ARGS(&buffer));
@@ -1068,10 +1083,14 @@ namespace wr
 
 			uint8_t* cpu_address;
 
+			CD3DX12_HEAP_PROPERTIES heap_properties_default = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+			CD3DX12_HEAP_PROPERTIES heap_properties_upload = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+			CD3DX12_RESOURCE_DESC buffer_desc = CD3DX12_RESOURCE_DESC::Buffer(new_size);
+
 			m_render_system.m_device->m_native->CreateCommittedResource(
-				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				&heap_properties_upload,
 				D3D12_HEAP_FLAG_NONE,
-				&CD3DX12_RESOURCE_DESC::Buffer(new_size),
+				&buffer_desc,
 				D3D12_RESOURCE_STATE_GENERIC_READ,
 				nullptr,
 				IID_PPV_ARGS(&new_staging));
@@ -1093,9 +1112,9 @@ namespace wr
 			SAFE_RELEASE(m_vertex_buffer->m_staging);
 
 			m_render_system.m_device->m_native->CreateCommittedResource(
-				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				&heap_properties_default,
 				D3D12_HEAP_FLAG_NONE,
-				&CD3DX12_RESOURCE_DESC::Buffer(new_size),
+				&buffer_desc,
 				static_cast<D3D12_RESOURCE_STATES>(m_vertex_buffer->m_target_resource_state),
 				nullptr,
 				IID_PPV_ARGS(&new_buffer));
@@ -1246,10 +1265,14 @@ namespace wr
 
 			uint8_t* cpu_address;
 
+			CD3DX12_HEAP_PROPERTIES heap_properties_default = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+			CD3DX12_HEAP_PROPERTIES heap_properties_upload = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD);
+			CD3DX12_RESOURCE_DESC buffer_desc = CD3DX12_RESOURCE_DESC::Buffer(new_size);
+
 			m_render_system.m_device->m_native->CreateCommittedResource(
-				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_UPLOAD),
+				&heap_properties_upload,
 				D3D12_HEAP_FLAG_NONE,
-				&CD3DX12_RESOURCE_DESC::Buffer(new_size),
+				&buffer_desc,
 				D3D12_RESOURCE_STATE_GENERIC_READ,
 				nullptr,
 				IID_PPV_ARGS(&new_staging));
@@ -1271,9 +1294,9 @@ namespace wr
 			SAFE_RELEASE(m_index_buffer->m_staging);
 
 			m_render_system.m_device->m_native->CreateCommittedResource(
-				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				&heap_properties_default,
 				D3D12_HEAP_FLAG_NONE,
-				&CD3DX12_RESOURCE_DESC::Buffer(new_size),
+				&buffer_desc,
 				static_cast<D3D12_RESOURCE_STATES>(m_index_buffer->m_target_resource_state),
 				nullptr,
 				IID_PPV_ARGS(&new_buffer));

--- a/src/d3d12/d3d12_model_pool.cpp
+++ b/src/d3d12/d3d12_model_pool.cpp
@@ -1054,7 +1054,7 @@ namespace wr
 		}
 
 		MemoryBlock* last_occupied_block = nullptr;
-		for (MemoryBlock* mem_block = m_vertex_heap_start_block; mem_block != nullptr; mem_block = mem_block->m_next_block)
+		for (mem_block = m_vertex_heap_start_block; mem_block != nullptr; mem_block = mem_block->m_next_block)
 		{
 			if (mem_block->m_free == false)
 			{
@@ -1236,7 +1236,7 @@ namespace wr
 		}
 
 		MemoryBlock* last_occupied_block = nullptr;
-		for (MemoryBlock* mem_block = m_index_heap_start_block; mem_block != nullptr; mem_block = mem_block->m_next_block)
+		for (mem_block = m_index_heap_start_block; mem_block != nullptr; mem_block = mem_block->m_next_block)
 		{
 			if (mem_block->m_free == false)
 			{

--- a/src/d3d12/d3d12_model_pool.cpp
+++ b/src/d3d12/d3d12_model_pool.cpp
@@ -181,7 +181,7 @@ namespace wr
 
 	void D3D12ModelPool::ShrinkVertexHeapToFit()
 	{
-		MemoryBlock* last_occupied_block;
+		MemoryBlock* last_occupied_block = nullptr;
 		for (MemoryBlock* mem_block = m_vertex_heap_start_block; mem_block != nullptr; mem_block = mem_block->m_next_block)
 		{
 			if (mem_block->m_free == false)
@@ -199,11 +199,9 @@ namespace wr
 		}
 
 		ID3D12Resource* old_buffer = m_vertex_buffer->m_buffer;
-		ID3D12Resource* new_buffer;
+		ID3D12Resource* new_buffer = nullptr;
 		ID3D12Resource* old_staging = m_vertex_buffer->m_staging;
-		ID3D12Resource* new_staging;
-
-		bool was_staged = m_vertex_buffer->m_is_staged;
+		ID3D12Resource* new_staging = nullptr;
 
 		uint8_t* cpu_address;
 
@@ -1040,7 +1038,7 @@ namespace wr
 			}
 		}
 
-		MemoryBlock* last_occupied_block;
+		MemoryBlock* last_occupied_block = nullptr;
 		for (MemoryBlock* mem_block = m_vertex_heap_start_block; mem_block != nullptr; mem_block = mem_block->m_next_block)
 		{
 			if (mem_block->m_free == false)
@@ -1083,7 +1081,7 @@ namespace wr
 
 			new_staging->Map(0, &read_range, reinterpret_cast<void**>(&(cpu_address)));
 
-			memcpy(cpu_address, m_vertex_buffer->m_cpu_address, std::min(static_cast<std::uint32_t>(new_size), m_vertex_buffer->m_size));
+			memcpy(cpu_address, m_vertex_buffer->m_cpu_address, std::min(new_size, m_vertex_buffer->m_size));
 
 			m_vertex_buffer->m_size = static_cast<std::uint32_t>(new_size);
 			m_vertex_buffer->m_is_staged = true;
@@ -1218,7 +1216,7 @@ namespace wr
 			}
 		}
 
-		MemoryBlock* last_occupied_block;
+		MemoryBlock* last_occupied_block = nullptr;
 		for (MemoryBlock* mem_block = m_index_heap_start_block; mem_block != nullptr; mem_block = mem_block->m_next_block)
 		{
 			if (mem_block->m_free == false)
@@ -1261,7 +1259,7 @@ namespace wr
 
 			new_staging->Map(0, &read_range, reinterpret_cast<void**>(&(cpu_address)));
 
-			memcpy(cpu_address, m_index_buffer->m_cpu_address, std::min(static_cast<std::uint32_t>(new_size), m_index_buffer->m_size));
+			memcpy(cpu_address, m_index_buffer->m_cpu_address, std::min(new_size, m_index_buffer->m_size));
 
 			m_index_buffer->m_size = static_cast<std::uint32_t>(new_size);
 			m_index_buffer->m_is_staged = true;

--- a/src/d3d12/d3d12_pipeline_state.cpp
+++ b/src/d3d12/d3d12_pipeline_state.cpp
@@ -137,7 +137,7 @@ namespace wr::d3d12
 		break;
 		}
 
-		HRESULT hr;
+		HRESULT hr = E_FAIL;
 		if (std::holds_alternative<D3D12_GRAPHICS_PIPELINE_STATE_DESC>(pso_desc))
 		{
 			hr = n_device->CreateGraphicsPipelineState(&std::get<D3D12_GRAPHICS_PIPELINE_STATE_DESC>(pso_desc), IID_PPV_ARGS(&pipeline_state->m_native));

--- a/src/d3d12/d3d12_readback_buffer.cpp
+++ b/src/d3d12/d3d12_readback_buffer.cpp
@@ -14,10 +14,13 @@ namespace wr::d3d12
 
 		std::uint32_t buffer_size_aligned_to_256 = SizeAlignTwoPower(description->m_buffer_width * description->m_bytes_per_pixel, 256) * description->m_buffer_height;
 
+		CD3DX12_HEAP_PROPERTIES heap_properties_readback = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK);
+		CD3DX12_RESOURCE_DESC buffer_desc = CD3DX12_RESOURCE_DESC::Buffer(buffer_size_aligned_to_256);
+
 		HRESULT res = native_device->CreateCommittedResource(
-			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_READBACK),
+			&heap_properties_readback,
 			D3D12_HEAP_FLAG_NONE,
-			&CD3DX12_RESOURCE_DESC::Buffer(buffer_size_aligned_to_256),
+			&buffer_desc,
 			D3D12_RESOURCE_STATE_COPY_DEST,
 			nullptr,
 			IID_PPV_ARGS(&readbackBuffer->m_resource));
@@ -36,7 +39,10 @@ namespace wr::d3d12
 			return nullptr;
 
 		void* memory = nullptr;
-		readback_buffer->m_resource->Map(0, &CD3DX12_RANGE(0, buffer_size), &memory);
+		CD3DX12_RANGE buffer_range = CD3DX12_RANGE(0, buffer_size);
+
+		readback_buffer->m_resource->Map(0, &buffer_range, &memory);
+
 		return memory;
 	}
 
@@ -45,7 +51,8 @@ namespace wr::d3d12
 		if (!readback_buffer)
 			return;
 
-		readback_buffer->m_resource->Unmap(0, &CD3DX12_RANGE(0, 0));
+		CD3DX12_RANGE buffer_range = CD3DX12_RANGE(0, 0);
+		readback_buffer->m_resource->Unmap(0, &buffer_range);
 	}
 
 	void SetName(ReadbackBufferResource* readback_buffer, std::wstring name)

--- a/src/d3d12/d3d12_render_target.cpp
+++ b/src/d3d12/d3d12_render_target.cpp
@@ -20,7 +20,14 @@ namespace wr::d3d12
 
 		for (auto i = 0u; i < descriptor.m_num_rtv_formats; i++)
 		{
-			CD3DX12_RESOURCE_DESC resource_desc = CD3DX12_RESOURCE_DESC::Tex2D((DXGI_FORMAT)descriptor.m_rtv_formats[i], width, height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+			CD3DX12_RESOURCE_DESC resource_desc = CD3DX12_RESOURCE_DESC::Tex2D((DXGI_FORMAT)descriptor.m_rtv_formats[i], 
+				width, 
+				height, 
+				1, 
+				1, 
+				1,
+				0, 
+				D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET | D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
 
 			D3D12_CLEAR_VALUE optimized_clear_value = {
 				(DXGI_FORMAT)descriptor.m_rtv_formats[i],
@@ -33,8 +40,10 @@ namespace wr::d3d12
 			// Create default heap
 			D3D12_RESOURCE_STATES state = (D3D12_RESOURCE_STATES)descriptor.m_initial_state;
 
+			CD3DX12_HEAP_PROPERTIES heap_properties_default = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+
 			TRY_M(n_device->CreateCommittedResource(
-				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+				&heap_properties_default,
 				D3D12_HEAP_FLAG_NONE,
 				&resource_desc,
 				state,
@@ -131,10 +140,13 @@ namespace wr::d3d12
 		depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
 		depthOptimizedClearValue.DepthStencil.Stencil = 0;
 
+		CD3DX12_HEAP_PROPERTIES heap_properties_default = CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT);
+		CD3DX12_RESOURCE_DESC tex_desc = CD3DX12_RESOURCE_DESC::Tex2D(depth_format, width, height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
+
 		TRY_M(n_device->CreateCommittedResource(
-			&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
+			&heap_properties_default,
 			D3D12_HEAP_FLAG_NONE,
-			&CD3DX12_RESOURCE_DESC::Tex2D(depth_format, width, height, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL),
+			&tex_desc,
 			D3D12_RESOURCE_STATE_DEPTH_WRITE,
 			&depthOptimizedClearValue,
 			IID_PPV_ARGS(&render_target->m_depth_stencil_buffer)

--- a/src/d3d12/d3d12_render_target.cpp
+++ b/src/d3d12/d3d12_render_target.cpp
@@ -31,11 +31,13 @@ namespace wr::d3d12
 			};
 
 			// Create default heap
+			D3D12_RESOURCE_STATES state = (D3D12_RESOURCE_STATES)descriptor.m_initial_state;
+
 			TRY_M(n_device->CreateCommittedResource(
 				&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT),
 				D3D12_HEAP_FLAG_NONE,
 				&resource_desc,
-				(D3D12_RESOURCE_STATES)descriptor.m_initial_state,
+				state,
 				&optimized_clear_value, // optimizes draw call
 				IID_PPV_ARGS(&render_target->m_render_targets[i])
 			), "Failed to create render target.");

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -375,8 +375,8 @@ namespace wr
 			if (properties.m_width.Get().has_value() || properties.m_height.Get().has_value())
 			{
 				auto retval = d3d12::CreateRenderTarget(m_device, 
-					properties.m_width.Get().value() * properties.m_resolution_scale.Get(),
-					properties.m_height.Get().value() * properties.m_resolution_scale.Get(),
+					static_cast<std::uint32_t>(properties.m_width.Get().value() * properties.m_resolution_scale.Get()),
+					static_cast<std::uint32_t>(properties.m_height.Get().value() * properties.m_resolution_scale.Get()),
 					desc);
 
 				for (auto i = 0; i < retval->m_render_targets.size(); i++)
@@ -386,8 +386,8 @@ namespace wr
 			else if (m_window.has_value())
 			{
 				auto retval = d3d12::CreateRenderTarget(m_device, 
-					m_window.value()->GetWidth() * properties.m_resolution_scale.Get(), 
-					m_window.value()->GetHeight() * properties.m_resolution_scale.Get(), 
+					static_cast<std::uint32_t>(m_window.value()->GetWidth() * properties.m_resolution_scale.Get()),
+					static_cast<std::uint32_t>(m_window.value()->GetHeight() * properties.m_resolution_scale.Get()),
 					desc);
 				for (auto i = 0; i < retval->m_render_targets.size(); i++)
 					retval->m_render_targets[i]->SetName(properties.m_name.Get().c_str());
@@ -1016,7 +1016,6 @@ namespace wr
 	void D3D12RenderSystem::Render_MeshNodes(temp::MeshBatches& batches, CameraNode* camera, CommandList* cmd_list)
 	{
 		auto n_cmd_list = static_cast<d3d12::CommandList*>(cmd_list);
-		auto frame_idx = GetFrameIdx();
 		auto d3d12_camera_cb = static_cast<D3D12ConstantBufferHandle*>(camera->m_camera_cb);
 	
 		d3d12::BindConstantBuffer(n_cmd_list, d3d12_camera_cb->m_native, 0, GetFrameIdx());
@@ -1080,7 +1079,7 @@ namespace wr
 				}
 				else
 				{
-					d3d12::Draw(n_cmd_list, n_mesh->m_vertex_count, batch.num_instances, n_mesh->m_vertex_staging_buffer_offset);
+					d3d12::Draw(n_cmd_list, static_cast<std::uint32_t>(n_mesh->m_vertex_count), batch.num_instances, n_mesh->m_vertex_staging_buffer_offset);
 				}
 			}
 		}

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -831,8 +831,8 @@ namespace wr
 
 			if (auto rt_handle = desc.global_root_signature.Get().value(); desc.global_root_signature.Get().has_value())
 			{
-				auto library = static_cast<D3D12RootSignature*>(RootSignatureRegistry::Get().Find(rt_handle));
-				n_desc.global_root_signature = library->m_native;
+				auto rs_library = static_cast<D3D12RootSignature*>(RootSignatureRegistry::Get().Find(rt_handle));
+				n_desc.global_root_signature = rs_library->m_native;
 			}
 
 			if (desc.local_root_signatures.Get().has_value())

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -824,9 +824,9 @@ namespace wr
 			d3d12::desc::StateObjectDesc n_desc;
 			n_desc.m_library = library->m_native;
 			n_desc.m_library_exports = desc.library_desc.Get().exports;
-			n_desc.max_attributes_size = desc.max_attributes_size.Get();
-			n_desc.max_payload_size = desc.max_payload_size.Get();
-			n_desc.max_recursion_depth = desc.max_recursion_depth.Get();
+			n_desc.max_attributes_size = static_cast<std::uint32_t>(desc.max_attributes_size.Get());
+			n_desc.max_payload_size = static_cast<std::uint32_t>(desc.max_payload_size.Get());
+			n_desc.max_recursion_depth = static_cast<std::uint32_t>(desc.max_recursion_depth.Get());
 			n_desc.m_hit_groups = desc.library_desc.Get().m_hit_groups;
 
 			if (auto rt_handle = desc.global_root_signature.Get().value(); desc.global_root_signature.Get().has_value())
@@ -1079,7 +1079,10 @@ namespace wr
 				}
 				else
 				{
-					d3d12::Draw(n_cmd_list, static_cast<std::uint32_t>(n_mesh->m_vertex_count), batch.num_instances, n_mesh->m_vertex_staging_buffer_offset);
+					d3d12::Draw(n_cmd_list, 
+						static_cast<std::uint32_t>(n_mesh->m_vertex_count), 
+						batch.num_instances, 
+						static_cast<std::uint32_t>(n_mesh->m_vertex_staging_buffer_offset));
 				}
 			}
 		}

--- a/src/d3d12/d3d12_renderer.cpp
+++ b/src/d3d12/d3d12_renderer.cpp
@@ -1038,16 +1038,18 @@ namespace wr
 				auto n_mesh = static_cast<D3D12ModelPool*>(model->m_model_pool)->GetMeshData(mesh.first->id);
 				if (model->m_model_pool != m_bound_model_pool || n_mesh->m_vertex_staging_buffer_stride != m_bound_model_pool_stride)
 				{
+					D3D12ModelPool* model_pool = static_cast<D3D12ModelPool*>(model->m_model_pool);
+
 					d3d12::BindVertexBuffer(n_cmd_list,
-						static_cast<D3D12ModelPool*>(model->m_model_pool)->GetVertexStagingBuffer(),
+						model_pool->GetVertexStagingBuffer(),
 						0,
-						static_cast<D3D12ModelPool*>(model->m_model_pool)->GetVertexStagingBuffer()->m_size,
+						model_pool->GetVertexStagingBuffer()->m_size,
 						n_mesh->m_vertex_staging_buffer_stride);
 
 					d3d12::BindIndexBuffer(n_cmd_list,
-						static_cast<D3D12ModelPool*>(model->m_model_pool)->GetIndexStagingBuffer(),
+						model_pool->GetIndexStagingBuffer(),
 						0,
-						static_cast<D3D12ModelPool*>(model->m_model_pool)->GetIndexStagingBuffer()->m_size);
+						static_cast<std::uint32_t>(model_pool->GetIndexStagingBuffer()->m_size));
 
 					m_bound_model_pool = static_cast<D3D12ModelPool*>(model->m_model_pool);
 					m_bound_model_pool_stride = n_mesh->m_vertex_staging_buffer_stride;

--- a/src/d3d12/d3d12_renderer.hpp
+++ b/src/d3d12/d3d12_renderer.hpp
@@ -35,9 +35,9 @@ namespace wr
 			DirectX::XMMATRIX m_projection;
 			DirectX::XMMATRIX m_inverse_projection;
 			DirectX::XMMATRIX m_inverse_view;
-			unsigned int m_is_hybrid;
-			unsigned int m_is_path_tracer;
-			unsigned int m_is_ao;
+			std::uint32_t m_is_hybrid = 0u;
+			std::uint32_t m_is_path_tracer = 0u;
+			std::uint32_t m_is_ao = 0u;
 		};
 
 		struct RTHybridCamera_CBData
@@ -46,19 +46,19 @@ namespace wr
 			DirectX::XMMATRIX m_inverse_projection;
 			DirectX::XMMATRIX m_inv_vp;
 
-			uint32_t m_padding[2];
-			float m_frame_idx;
-			float m_intensity;
+			uint32_t m_padding[2] = { 0u };
+			float m_frame_idx = 0.0f;
+			float m_intensity = 0.0f;
 		};
 
 		struct RTAO_CBData
 		{
 			DirectX::XMMATRIX m_inv_vp;
 
-			float bias;
-			float radius;
-			float power;
-			unsigned int sample_count;
+			float bias = 0.0f;
+			float radius = 0.0f;
+			float power = 0.0f;
+			std::uint32_t sample_count = 0u;
 		};
 
 		struct RayTracingCamera_CBData
@@ -67,30 +67,30 @@ namespace wr
 			DirectX::XMMATRIX m_inverse_view_projection;
 			DirectX::XMVECTOR m_camera_position;
 
-			float light_radius;
-			float metal;
-			float roughness;
-			float intensity;
+			float light_radius = 0.0f;
+			float metal = 0.0f;
+			float roughness = 0.0f;
+			float intensity = 0.0f;
 		};
 
 		struct RayTracingMaterial_CBData
 		{
-			std::uint32_t albedo_id;
-			std::uint32_t normal_id;
-			std::uint32_t roughness_id;
-			std::uint32_t metallicness_id;
-			std::uint32_t emissive_id;
-			std::uint32_t ao_id;
+			std::uint32_t albedo_id = 0u;
+			std::uint32_t normal_id = 0u;
+			std::uint32_t roughness_id = 0u;
+			std::uint32_t metallicness_id = 0u;
+			std::uint32_t emissive_id = 0u;
+			std::uint32_t ao_id = 0u;
 
-			DirectX::XMFLOAT2 padding;
+			std::uint32_t padding[2] = { 0u };
 			Material::MaterialData material_data;
 		};
 
 		struct RayTracingOffset_CBData
 		{
-			std::uint32_t material_idx;
-			std::uint32_t idx_offset;
-			std::uint32_t vertex_offset;
+			std::uint32_t material_idx = 0u;
+			std::uint32_t idx_offset = 0u;
+			std::uint32_t vertex_offset = 0u;
 		};
 
 		static const constexpr float size = 1.0f;

--- a/src/d3d12/d3d12_renderer.hpp
+++ b/src/d3d12/d3d12_renderer.hpp
@@ -31,10 +31,10 @@ namespace wr
 	{
 		struct ProjectionView_CBData
 		{
-			DirectX::XMMATRIX m_view;
-			DirectX::XMMATRIX m_projection;
-			DirectX::XMMATRIX m_inverse_projection;
-			DirectX::XMMATRIX m_inverse_view;
+			DirectX::XMMATRIX m_view = DirectX::XMMatrixIdentity();
+			DirectX::XMMATRIX m_projection = DirectX::XMMatrixIdentity();
+			DirectX::XMMATRIX m_inverse_projection = DirectX::XMMatrixIdentity();
+			DirectX::XMMATRIX m_inverse_view = DirectX::XMMatrixIdentity();
 			std::uint32_t m_is_hybrid = 0u;
 			std::uint32_t m_is_path_tracer = 0u;
 			std::uint32_t m_is_ao = 0u;
@@ -42,9 +42,9 @@ namespace wr
 
 		struct RTHybridCamera_CBData
 		{
-			DirectX::XMMATRIX m_inverse_view;
-			DirectX::XMMATRIX m_inverse_projection;
-			DirectX::XMMATRIX m_inv_vp;
+			DirectX::XMMATRIX m_inverse_view = DirectX::XMMatrixIdentity();
+			DirectX::XMMATRIX m_inverse_projection = DirectX::XMMatrixIdentity();
+			DirectX::XMMATRIX m_inv_vp = DirectX::XMMatrixIdentity();
 
 			uint32_t m_padding[2] = { 0u };
 			float m_frame_idx = 0.0f;
@@ -53,7 +53,7 @@ namespace wr
 
 		struct RTAO_CBData
 		{
-			DirectX::XMMATRIX m_inv_vp;
+			DirectX::XMMATRIX m_inv_vp = DirectX::XMMatrixIdentity();
 
 			float bias = 0.0f;
 			float radius = 0.0f;
@@ -63,9 +63,9 @@ namespace wr
 
 		struct RayTracingCamera_CBData
 		{
-			DirectX::XMMATRIX m_view;
-			DirectX::XMMATRIX m_inverse_view_projection;
-			DirectX::XMVECTOR m_camera_position;
+			DirectX::XMMATRIX m_view = DirectX::XMMatrixIdentity();
+			DirectX::XMMATRIX m_inverse_view_projection = DirectX::XMMatrixIdentity();
+			DirectX::XMVECTOR m_camera_position = DirectX::XMVectorZero();
 
 			float light_radius = 0.0f;
 			float metal = 0.0f;

--- a/src/d3d12/d3d12_resource_pool_texture.cpp
+++ b/src/d3d12/d3d12_resource_pool_texture.cpp
@@ -137,8 +137,6 @@ namespace wr
 		{
 			d3d12::CommandList* cmdlist = static_cast<d3d12::CommandList*>(cmd_list);
 
-			int frame = m_render_system.GetFrameIdx();
-
 			std::vector<d3d12::TextureResource*> unstaged_textures;
 			std::vector<d3d12::TextureResource*> need_mipmapping;
 
@@ -310,7 +308,7 @@ namespace wr
 
 		TextureHandle texture_handle;
 		texture_handle.m_pool = this;
-		texture_handle.m_id = texture_id;
+		texture_handle.m_id = static_cast<std::uint32_t>(texture_id);
 
 		m_staged_textures.insert(std::make_pair(texture_id, texture));
 
@@ -388,7 +386,7 @@ namespace wr
 
 		TextureHandle texture_handle;
 		texture_handle.m_pool = this;
-		texture_handle.m_id = texture_id;
+		texture_handle.m_id = static_cast<std::uint32_t>(texture_id);
 
 		m_staged_textures.insert(std::make_pair(texture_id, texture));
 
@@ -482,18 +480,18 @@ namespace wr
 		}
 		else
 		{
-			mip_lvls = metadata.mipLevels;
+			mip_lvls = static_cast<std::uint32_t>(metadata.mipLevels);
 		}
 
 		Format texture_format = static_cast<wr::Format>(metadata.format);
 
 		d3d12::desc::TextureDesc desc;
 
-		desc.m_width = metadata.width;
-		desc.m_height = metadata.height;
+		desc.m_width = static_cast<std::uint32_t>(metadata.width);
+		desc.m_height = static_cast<std::uint32_t>(metadata.height);
 		desc.m_is_cubemap = metadata.IsCubemap();
-		desc.m_depth = metadata.depth;
-		desc.m_array_size = metadata.arraySize;
+		desc.m_depth = static_cast<std::uint32_t>(metadata.depth);
+		desc.m_array_size = static_cast<std::uint32_t>(metadata.arraySize);
 		desc.m_mip_levels = mip_lvls;
 		desc.m_texture_format = texture_format;
 		desc.m_initial_state = ResourceState::COPY_DEST;
@@ -521,7 +519,7 @@ namespace wr
 
 		TextureHandle texture_handle;
 		texture_handle.m_pool = this;
-		texture_handle.m_id = texture_id;
+		texture_handle.m_id = static_cast<std::uint32_t>(texture_id);
 
 		m_unstaged_textures.insert(std::make_pair(texture_id, std::make_pair(texture, image)));
 
@@ -588,18 +586,18 @@ namespace wr
 		}
 		else
 		{
-			mip_lvls = metadata.mipLevels;
+			mip_lvls = static_cast<std::uint32_t>(metadata.mipLevels);
 		}
 
 		Format texture_format = static_cast<wr::Format>(metadata.format);
 
 		d3d12::desc::TextureDesc desc;
 
-		desc.m_width = metadata.width;
-		desc.m_height = metadata.height;
+		desc.m_width = static_cast<std::uint32_t>(metadata.width);
+		desc.m_height = static_cast<std::uint32_t>(metadata.height);
 		desc.m_is_cubemap = metadata.IsCubemap();
-		desc.m_depth = metadata.depth;
-		desc.m_array_size = metadata.arraySize;
+		desc.m_depth = static_cast<std::uint32_t>(metadata.depth);
+		desc.m_array_size = static_cast<std::uint32_t>(metadata.arraySize);
 		desc.m_mip_levels = mip_lvls;
 		desc.m_texture_format = texture_format;
 		desc.m_initial_state = ResourceState::COPY_DEST;
@@ -629,7 +627,7 @@ namespace wr
 
 		TextureHandle texture_handle;
 		texture_handle.m_pool = this;
-		texture_handle.m_id = texture_id;
+		texture_handle.m_id = static_cast<std::uint32_t>(texture_id);
 
 		m_unstaged_textures.insert(std::make_pair(texture_id, std::make_pair(texture, image)));
 
@@ -664,7 +662,6 @@ namespace wr
 	{
 		wr::d3d12::CommandList* d3d12_cmd_list = static_cast<wr::d3d12::CommandList*>(cmd_list);
 		D3D12Pipeline* pipeline = static_cast<D3D12Pipeline*>(PipelineRegistry::Get().Find(pipelines::mip_mapping));
-		auto device = m_render_system.m_device;
 
 		d3d12::BindComputePipeline(d3d12_cmd_list, pipeline->m_native);
 
@@ -703,8 +700,8 @@ namespace wr
 
 		for (uint32_t src_mip = 0; src_mip < texture->m_mip_levels - 1u;)
 		{
-			uint32_t src_width = texture->m_width >> src_mip;
-			uint32_t src_height = texture->m_height >> src_mip;
+			uint32_t src_width = static_cast<std::uint32_t>(texture->m_width) >> src_mip;
+			uint32_t src_height = static_cast<std::uint32_t>(texture->m_height) >> src_mip;
 			uint32_t dst_width = src_width >> 1;
 			uint32_t dst_height = src_height >> 1;
 
@@ -730,7 +727,7 @@ namespace wr
 			// Maximum number of mips to generate is 4.
 			mip_count = std::min<DWORD>(4, mip_count + 1);
 			// Clamp to total number of mips left over.
-			mip_count = ((src_mip + mip_count) > texture->m_mip_levels) ? texture->m_mip_levels - src_mip : mip_count;
+			mip_count = ((static_cast<DWORD>(src_mip) + mip_count) > texture->m_mip_levels) ? static_cast<DWORD>(texture->m_mip_levels - src_mip) : mip_count;
 
 			// Dimensions should not reduce to 0.
 			// This can happen if the width and height are not the same.
@@ -750,7 +747,7 @@ namespace wr
 
 			for (uint32_t mip = 0; mip < mip_count; ++mip)
 			{
-				size_t idx = src_mip + mip + 1;
+				size_t idx = static_cast<size_t>(src_mip + mip + 1);
 
 				d3d12::Transition(d3d12_cmd_list, texture, texture->m_subresource_states[idx], ResourceState::UNORDERED_ACCESS, idx, 1);
 
@@ -776,7 +773,7 @@ namespace wr
 
 			for (uint32_t mip = 0; mip < mip_count; ++mip)
 			{
-				size_t idx = src_mip + mip + 1;
+				size_t idx = static_cast<size_t>(src_mip + mip + 1);
 
 				d3d12::Transition(d3d12_cmd_list, texture, texture->m_subresource_states[idx], ResourceState::PIXEL_SHADER_RESOURCE, idx, 1);
 			}
@@ -795,13 +792,13 @@ namespace wr
 
 		//Create new resource with UAV compatible format
 		d3d12::desc::TextureDesc copy_desc;
-		copy_desc.m_width = texture->m_width;
-		copy_desc.m_height = texture->m_height;
-		copy_desc.m_depth = texture->m_depth;
-		copy_desc.m_array_size = texture->m_array_size;
+		copy_desc.m_width = static_cast<std::uint32_t>(texture->m_width);
+		copy_desc.m_height = static_cast<std::uint32_t>(texture->m_height);
+		copy_desc.m_depth = static_cast<std::uint32_t>(texture->m_depth);
+		copy_desc.m_array_size = static_cast<std::uint32_t>(texture->m_array_size);
 		copy_desc.m_initial_state = ResourceState::COMMON;
 		copy_desc.m_is_cubemap = texture->m_is_cubemap;
-		copy_desc.m_mip_levels = texture->m_mip_levels;
+		copy_desc.m_mip_levels = static_cast<std::uint32_t>(texture->m_mip_levels);
 		copy_desc.m_texture_format = Format::R8G8B8A8_UNORM;
 
 		// Create a heap to alias the resource. This is used to copy the resource without 
@@ -810,7 +807,6 @@ namespace wr
 		auto resourceDesc = resource->GetDesc();
 
 		auto allocation_info = device->m_native->GetResourceAllocationInfo(0, 1, &resourceDesc);
-		auto buffer_size = GetRequiredIntermediateSize(resource, 0, resourceDesc.MipLevels);
 
 		d3d12::Heap<wr::HeapOptimization::BIG_STATIC_BUFFERS>* heap;
 		heap = d3d12::CreateHeap_BSBO(device, allocation_info.SizeInBytes, ResourceType::TEXTURE, 1);
@@ -857,12 +853,12 @@ namespace wr
 		//Create copy of the texture and store it for later deletion.
 		d3d12::desc::TextureDesc copy_desc;
 
-		copy_desc.m_width = texture->m_width;
-		copy_desc.m_height = texture->m_height;
+		copy_desc.m_width = static_cast<std::uint32_t>(texture->m_width);
+		copy_desc.m_height = static_cast<std::uint32_t>(texture->m_height);
 		copy_desc.m_is_cubemap = texture->m_is_cubemap;
-		copy_desc.m_depth = texture->m_depth;
-		copy_desc.m_array_size = texture->m_array_size;
-		copy_desc.m_mip_levels = texture->m_mip_levels;
+		copy_desc.m_depth = static_cast<std::uint32_t>(texture->m_depth);
+		copy_desc.m_array_size = static_cast<std::uint32_t>(texture->m_array_size);
+		copy_desc.m_mip_levels = static_cast<std::uint32_t>(texture->m_mip_levels);
 		copy_desc.m_texture_format = d3d12::RemoveSRGB(texture->m_format);
 		copy_desc.m_initial_state = ResourceState::COPY_DEST;
 
@@ -887,14 +883,14 @@ namespace wr
 		DescriptorAllocation srv_alloc = m_mipmapping_allocator->Allocate();
 		d3d12::DescHeapCPUHandle srv_handle = srv_alloc.GetDescriptorHandle();
 
-		d3d12::CreateSRVFromCubemapFace(texture, srv_handle, texture->m_mip_levels, 0, array_slice);
+		d3d12::CreateSRVFromCubemapFace(texture, srv_handle, static_cast<unsigned int>(texture->m_mip_levels), 0, array_slice);
 
 		MipMapping_CB generate_mips_cb;
 
 		for (uint32_t src_mip = 0; src_mip < texture->m_mip_levels - 1u;)
 		{
-			uint32_t src_width = texture->m_width >> src_mip;
-			uint32_t src_height = texture->m_height >> src_mip;
+			uint32_t src_width = static_cast<std::uint32_t>(texture->m_width) >> src_mip;
+			uint32_t src_height = static_cast<std::uint32_t>(texture->m_height) >> src_mip;
 			uint32_t dst_width = src_width >> 1;
 			uint32_t dst_height = src_height >> 1;
 
@@ -920,7 +916,7 @@ namespace wr
 			// Maximum number of mips to generate is 4.
 			mip_count = std::min<DWORD>(4, mip_count + 1);
 			// Clamp to total number of mips left over.
-			mip_count = ((src_mip + mip_count) > texture->m_mip_levels) ? texture->m_mip_levels - src_mip : mip_count;
+			mip_count = ((static_cast<DWORD>(src_mip) + mip_count) > texture->m_mip_levels) ? static_cast<DWORD>(texture->m_mip_levels - src_mip) : mip_count;
 
 			// Dimensions should not reduce to 0.
 			// This can happen if the width and height are not the same.
@@ -940,7 +936,7 @@ namespace wr
 
 			for (uint32_t mip = 0; mip < mip_count; ++mip)
 			{
-				size_t idx = src_mip + mip + 1;
+				size_t idx = static_cast<size_t>(src_mip + mip + 1);
 
 				d3d12::Transition(d3d12_cmd_list, texture, texture->m_subresource_states[idx], ResourceState::UNORDERED_ACCESS, idx, 1);
 
@@ -966,7 +962,7 @@ namespace wr
 
 			for (uint32_t mip = 0; mip < mip_count; ++mip)
 			{
-				size_t idx = src_mip + mip + 1;
+				size_t idx = static_cast<size_t>(src_mip + mip + 1);
 
 				d3d12::Transition(d3d12_cmd_list, texture, texture->m_subresource_states[idx], ResourceState::PIXEL_SHADER_RESOURCE, idx, 1);
 			}

--- a/src/d3d12/d3d12_resource_pool_texture.cpp
+++ b/src/d3d12/d3d12_resource_pool_texture.cpp
@@ -116,7 +116,7 @@ namespace wr
 		
 		while(m_staged_textures.size() > 0)
 		{
-			TextureHandle handle = { this, m_staged_textures.begin()->first };
+			TextureHandle handle = { this, static_cast<uint32_t>(m_staged_textures.begin()->first) };
 			D3D12TexturePool::Unload(handle);
 		}
 	}
@@ -747,7 +747,7 @@ namespace wr
 
 			for (uint32_t mip = 0; mip < mip_count; ++mip)
 			{
-				size_t idx = static_cast<size_t>(src_mip + mip + 1);
+				std::uint32_t idx = src_mip + mip + 1u;
 
 				d3d12::Transition(d3d12_cmd_list, texture, texture->m_subresource_states[idx], ResourceState::UNORDERED_ACCESS, idx, 1);
 
@@ -773,7 +773,7 @@ namespace wr
 
 			for (uint32_t mip = 0; mip < mip_count; ++mip)
 			{
-				size_t idx = static_cast<size_t>(src_mip + mip + 1);
+				std::uint32_t idx = src_mip + mip + 1u;
 
 				d3d12::Transition(d3d12_cmd_list, texture, texture->m_subresource_states[idx], ResourceState::PIXEL_SHADER_RESOURCE, idx, 1);
 			}
@@ -936,7 +936,7 @@ namespace wr
 
 			for (uint32_t mip = 0; mip < mip_count; ++mip)
 			{
-				size_t idx = static_cast<size_t>(src_mip + mip + 1);
+				uint32_t idx = src_mip + mip + 1u;
 
 				d3d12::Transition(d3d12_cmd_list, texture, texture->m_subresource_states[idx], ResourceState::UNORDERED_ACCESS, idx, 1);
 
@@ -962,7 +962,7 @@ namespace wr
 
 			for (uint32_t mip = 0; mip < mip_count; ++mip)
 			{
-				size_t idx = static_cast<size_t>(src_mip + mip + 1);
+				uint32_t idx = src_mip + mip + 1u;
 
 				d3d12::Transition(d3d12_cmd_list, texture, texture->m_subresource_states[idx], ResourceState::PIXEL_SHADER_RESOURCE, idx, 1);
 			}

--- a/src/d3d12/d3d12_root_signature.cpp
+++ b/src/d3d12/d3d12_root_signature.cpp
@@ -35,7 +35,7 @@ namespace wr::d3d12
 
 		auto num_samplers = static_cast<std::uint32_t>(create_info.m_samplers.size());
 		std::vector<D3D12_STATIC_SAMPLER_DESC> samplers(num_samplers);
-		for (auto i = 0; i < num_samplers; i++)
+		for (auto i = 0u; i < num_samplers; i++)
 		{
 			auto sampler_info = create_info.m_samplers[i];
 
@@ -61,7 +61,7 @@ namespace wr::d3d12
 		}
 
 		CD3DX12_ROOT_SIGNATURE_DESC root_signature_desc;
-		root_signature_desc.Init(create_info.m_parameters.size(),
+		root_signature_desc.Init(static_cast<UINT>(create_info.m_parameters.size()),
 			create_info.m_parameters.data(),
 			num_samplers,
 			samplers.data(),

--- a/src/d3d12/d3d12_shader.cpp
+++ b/src/d3d12/d3d12_shader.cpp
@@ -83,9 +83,9 @@ namespace wr::d3d12
 			wentry.c_str(),         // entry point function
 			wshader_type.c_str(),   // target profile
 #ifdef _DEBUG
-			d3d12::settings::debug_shader_args.data(), d3d12::settings::debug_shader_args.size(),
+			d3d12::settings::debug_shader_args.data(), static_cast<uint32_t>(d3d12::settings::debug_shader_args.size()),
 #else
-			d3d12::settings::release_shader_args.data(), d3d12::settings::release_shader_args.size(),
+			d3d12::settings::release_shader_args.data(), static_cast<uint32_t>(d3d12::settings::release_shader_args.size()),
 #endif
 			defines.data(), static_cast<std::uint32_t>(defines.size()),       // name/value defines and their count
 			include_handler,          // handler for #include directives

--- a/src/d3d12/d3d12_structs.hpp
+++ b/src/d3d12/d3d12_structs.hpp
@@ -39,9 +39,9 @@ namespace wr::d3d12
 		{
 			ResourceState m_initial_state = ResourceState::RENDER_TARGET;
 			bool m_create_dsv_buffer = true;
-			Format m_dsv_format;
-			std::array<Format, 8> m_rtv_formats;
-			unsigned int m_num_rtv_formats;
+			Format m_dsv_format = wr::Format::UNKNOWN;
+			std::array<Format, 8> m_rtv_formats = { wr::Format::UNKNOWN };
+			std::uint32_t m_num_rtv_formats = 0u;
 			float m_clear_color[4] = { 0.f, 0.f, 0.f, 0.f };
 		};
 
@@ -50,27 +50,27 @@ namespace wr::d3d12
 			ResourceState m_initial_state = ResourceState::COPY_DEST;
 			Format m_texture_format = Format::UNKNOWN;
 
-			unsigned int m_width = 0;
-			unsigned int m_height = 0;;
-			unsigned int m_depth = 0;;
-			unsigned int m_array_size = 0;;
-			unsigned int m_mip_levels = 0;;
+			std::uint32_t m_width = 0u;
+			std::uint32_t m_height = 0u;
+			std::uint32_t m_depth = 0u;
+			std::uint32_t m_array_size = 0u;
+			std::uint32_t m_mip_levels = 0u;
 
 			bool m_is_cubemap = false;
 		};
 
 		struct ReadbackDesc
 		{
-			unsigned int m_buffer_width;
-			unsigned int m_buffer_height;
-			unsigned int m_bytes_per_pixel;
+			std::uint32_t m_buffer_width = 0u;
+			std::uint32_t m_buffer_height = 0u;
+			std::uint32_t m_bytes_per_pixel = 0u;
 		};
 
 		struct PipelineStateDesc
 		{
 			Format m_dsv_format;
-			std::array<Format, 8> m_rtv_formats;
-			unsigned int m_num_rtv_formats;
+			std::array<Format, 8> m_rtv_formats = { wr::Format::UNKNOWN };
+			std::uint32_t m_num_rtv_formats = 0U;
 
 			PipelineType m_type = PipelineType::GRAPHICS_PIPELINE;
 			CullMode m_cull_mode = CullMode::CULL_BACK;
@@ -98,52 +98,52 @@ namespace wr::d3d12
 
 		struct DescriptorHeapDesc
 		{
-			unsigned int m_num_descriptors = 1;
+			std::uint32_t m_num_descriptors = 1u;
 			DescriptorHeapType m_type = DescriptorHeapType::DESC_HEAP_TYPE_CBV_SRV_UAV;
 			bool m_shader_visible = true;
-			uint32_t m_versions = 1;
+			uint32_t m_versions = 1u;
 		};
 
 		struct GeometryDesc
 		{
 			StagingBuffer* vertex_buffer = nullptr;
-			std::optional<StagingBuffer*> index_buffer;
+			std::optional<StagingBuffer*> index_buffer = std::nullopt;
 
-			std::uint32_t m_num_vertices = 0;
-			std::uint32_t m_num_indices = 0;
-			std::uint32_t m_vertices_offset = 0;
-			std::uint32_t m_indices_offset = 0;
+			std::uint32_t m_num_vertices = 0u;
+			std::uint32_t m_num_indices = 0u;
+			std::uint32_t m_vertices_offset = 0u;
+			std::uint32_t m_indices_offset = 0u;
 
-			std::uint32_t m_vertex_stride = 0;
+			std::uint32_t m_vertex_stride = 0u;
 		};
 
 		struct StateObjectDesc
 		{
-			Shader* m_library;
+			Shader* m_library = nullptr;
 			std::vector<std::wstring> m_library_exports;
 			std::vector<std::pair<std::wstring, std::wstring>> m_hit_groups; // first = hit group | second = entry
 
-			std::uint32_t max_payload_size;
-			std::uint32_t max_attributes_size;
-			std::uint32_t max_recursion_depth;
+			std::uint32_t max_payload_size = 0u;
+			std::uint32_t max_attributes_size = 0u;
+			std::uint32_t max_recursion_depth = 0u;
 
-			std::optional<RootSignature*> global_root_signature;
-			std::optional<std::vector<RootSignature*>> local_root_signatures;
+			std::optional<RootSignature*> global_root_signature = std::nullopt;
+			std::optional<std::vector<RootSignature*>> local_root_signatures = { std::nullopt };
 		};
 
 	} /* desc */
 
 	struct Device
 	{
-		IDXGIAdapter4* m_adapter;
-		ID3D12Device5* m_native;
-		IDXGIFactory6* m_dxgi_factory;
+		IDXGIAdapter4* m_adapter = nullptr;
+		ID3D12Device5* m_native = nullptr;
+		IDXGIFactory6* m_dxgi_factory = nullptr;
 		D3D_FEATURE_LEVEL m_feature_level;
 
 		SYSTEM_INFO m_sys_info;
 		DXGI_ADAPTER_DESC3 m_adapter_info;
-		ID3D12Debug1* m_debug_controller;
-		ID3D12InfoQueue* m_info_queue;
+		ID3D12Debug1* m_debug_controller = nullptr;
+		ID3D12InfoQueue* m_info_queue = nullptr;
 		
 		static IDxcCompiler2* m_compiler;
 
@@ -151,10 +151,10 @@ namespace wr::d3d12
 		std::bitset<DXGI_FORMAT_V408> m_optional_formats;
 
 		// Fallback
-		bool m_dxr_fallback_support;
-		bool m_dxr_support;
+		bool m_dxr_fallback_support = false;
+		bool m_dxr_support = false;
 		RaytracingType m_rt_type;
-		ID3D12RaytracingFallbackDevice* m_fallback_native;
+		ID3D12RaytracingFallbackDevice* m_fallback_native = nullptr;
 
 		bool IsFallback() 
 		{
@@ -164,14 +164,14 @@ namespace wr::d3d12
 
 	struct CommandQueue
 	{
-		ID3D12CommandQueue* m_native;
+		ID3D12CommandQueue* m_native = nullptr;
 	};
 
 	struct CommandList
 	{
 		std::vector<ID3D12CommandAllocator*> m_allocators;
-		ID3D12GraphicsCommandList4* m_native;
-		ID3D12RaytracingFallbackCommandList* m_native_fallback;
+		ID3D12GraphicsCommandList4* m_native = nullptr;
+		ID3D12RaytracingFallbackCommandList* m_native_fallback = nullptr;
 
 		// Dynamic descriptor heap where staging happens
 		std::unique_ptr<DynamicDescriptorHeap> m_dynamic_descriptor_heaps[static_cast<size_t>(DescriptorHeapType::DESC_HEAP_TYPE_NUM_TYPES)];
@@ -185,65 +185,65 @@ namespace wr::d3d12
 
 	struct CommandSignature
 	{
-		ID3D12CommandSignature* m_native;
+		ID3D12CommandSignature* m_native = nullptr;
 	};
 
 	struct RenderTarget
 	{
 		desc::RenderTargetDesc m_create_info;
-		unsigned int m_frame_idx;
-		unsigned int m_num_render_targets;
-		unsigned int m_width;
-		unsigned int m_height;
+		std::uint32_t m_frame_idx = 0u;
+		std::uint32_t m_num_render_targets = 0u;
+		std::uint32_t m_width = 0u;
+		std::uint32_t m_height = 0u;
 
 		std::vector<ID3D12Resource*> m_render_targets;
-		ID3D12DescriptorHeap* m_rtv_descriptor_heap;
-		unsigned int m_rtv_descriptor_increment_size;
+		ID3D12DescriptorHeap* m_rtv_descriptor_heap = nullptr;
+		std::uint32_t m_rtv_descriptor_increment_size = 0u;
 
-		ID3D12Resource* m_depth_stencil_buffer;
-		ID3D12DescriptorHeap* m_depth_stencil_resource_heap;
+		ID3D12Resource* m_depth_stencil_buffer = nullptr;
+		ID3D12DescriptorHeap* m_depth_stencil_resource_heap = nullptr;
 	};
 
 	struct RenderWindow : public RenderTarget
 	{
-		IDXGISwapChain4* m_swap_chain;
+		IDXGISwapChain4* m_swap_chain = nullptr;
 	};
 
 	struct Fence
 	{
-		ID3D12Fence1* m_native;
-		HANDLE m_fence_event;
-		UINT64 m_fence_value;
+		ID3D12Fence1* m_native = nullptr;
+		HANDLE m_fence_event = nullptr;
+		UINT64 m_fence_value = static_cast<UINT64>(0u);
 	};
 
 	struct RootSignature
 	{
 		desc::RootSignatureDesc m_create_info;
-		ID3D12RootSignature* m_native;
+		ID3D12RootSignature* m_native = nullptr;
 
-		std::uint32_t m_num_descriptors_per_table[32];
-		std::uint32_t m_sampler_table_bit_mask;
-		std::uint32_t m_descriptor_table_bit_mask;
+		std::uint32_t m_num_descriptors_per_table[32] = { 0u };
+		std::uint32_t m_sampler_table_bit_mask = 0u;
+		std::uint32_t m_descriptor_table_bit_mask = 0u;
 	};
 
 	struct PipelineState;
 	struct StateObject;
 	struct Shader
 	{
-		IDxcBlob* m_native;
-		std::string m_path;
-		std::string m_entry;
+		IDxcBlob* m_native = nullptr;
+		std::string m_path = "";
+		std::string m_entry = "";
 		ShaderType m_type;
 	};
 
 	struct PipelineState
 	{
-		ID3D12PipelineState* m_native;
-		RootSignature* m_root_signature;
-		Shader* m_vertex_shader;
-		Shader* m_pixel_shader;
-		Shader* m_compute_shader;
-		Device* m_device; // only used for refinalization.
+		ID3D12PipelineState* m_native = nullptr;
+		RootSignature* m_root_signature = nullptr;
+		Shader* m_vertex_shader = nullptr;
+		Shader* m_pixel_shader = nullptr;
+		Shader* m_compute_shader = nullptr;
+		Device* m_device = nullptr; // only used for refinalization.
 		desc::PipelineStateDesc m_desc;
 	};
 
@@ -257,7 +257,7 @@ namespace wr::d3d12
 	{
 		desc::DescriptorHeapDesc m_create_info;
 		std::vector<ID3D12DescriptorHeap*> m_native;
-		unsigned int m_increment_size;
+		std::uint32_t m_increment_size = 0u;
 	};
 
 	struct DescHeapCPUHandle
@@ -272,19 +272,19 @@ namespace wr::d3d12
 
 	struct StagingBuffer
 	{
-		ID3D12Resource* m_buffer;
-		ID3D12Resource* m_staging;
-		unsigned int m_size;
-		unsigned int m_stride_in_bytes;
+		ID3D12Resource* m_buffer = nullptr;
+		ID3D12Resource* m_staging = nullptr;
+		std::uint64_t m_size = 0u;
+		std::uint64_t m_stride_in_bytes = 0u;
 		ResourceState m_target_resource_state;
 		D3D12_GPU_VIRTUAL_ADDRESS m_gpu_address;
-		std::uint8_t* m_cpu_address;
-		bool m_is_staged;
+		std::uint8_t* m_cpu_address = nullptr;
+		bool m_is_staged = false;
 	};
 
 	struct ReadbackBufferResource : ReadbackBuffer
 	{
-		ID3D12Resource* m_resource;
+		ID3D12Resource* m_resource = nullptr;
 	};
 
 	struct HeapResource;
@@ -304,8 +304,8 @@ namespace wr::d3d12
 		struct Heap<HeapOptimization::SMALL_BUFFERS>
 		{
 			std::vector<HeapResource*> m_resources;
-			std::uint8_t* m_cpu_address;
-			ID3D12Resource* m_native;
+			std::uint8_t* m_cpu_address = nullptr;
+			ID3D12Resource* m_native = nullptr;
 		};
 
 		/*! Big Buffer Optimization */
@@ -314,7 +314,7 @@ namespace wr::d3d12
 		struct Heap<HeapOptimization::BIG_BUFFERS>
 		{
 			std::vector<std::pair<HeapResource*, std::vector<ID3D12Resource*>>> m_resources;
-			ID3D12Heap* m_native;
+			ID3D12Heap* m_native = nullptr;
 		};
 
 		template<>
@@ -322,18 +322,18 @@ namespace wr::d3d12
 		{
 			std::vector<HeapResource*> m_resources;
 			D3D12_GPU_VIRTUAL_ADDRESS m_gpu_address;
-			ID3D12Resource* m_native;
-			ID3D12Resource* m_staging_buffer;
-			std::uint8_t* m_cpu_address;
+			ID3D12Resource* m_native = nullptr;
+			ID3D12Resource* m_staging_buffer = nullptr;
+			std::uint8_t* m_cpu_address = nullptr;
 		};
 
 		template<>
 		struct Heap<HeapOptimization::BIG_STATIC_BUFFERS> 
 		{
 			std::vector<std::pair<HeapResource*, std::vector<ID3D12Resource*>>> m_resources;
-			ID3D12Heap* m_native;
-			ID3D12Resource* m_staging_buffer;
-			std::uint8_t* m_cpu_address;
+			ID3D12Heap* m_native = nullptr;
+			ID3D12Resource* m_staging_buffer = nullptr;
+			std::uint8_t* m_cpu_address = nullptr;
 		};
 
 	} /* detail */
@@ -342,10 +342,10 @@ namespace wr::d3d12
 	struct Heap : detail::Heap<O>
 	{
 		bool m_mapped;
-		unsigned int m_versioning_count;
-		std::uint64_t m_current_offset;
-		std::uint64_t m_heap_size;
-		std::uint64_t m_alignment;
+		std::uint32_t m_versioning_count = 0u;
+		std::uint64_t m_current_offset = 0u;
+		std::uint64_t m_heap_size = 0u;
+		std::uint64_t m_alignment = 0u;
 		std::vector<std::uint64_t> m_bitmap;
 	};
 
@@ -361,41 +361,41 @@ namespace wr::d3d12
 
 		std::vector<D3D12_GPU_VIRTUAL_ADDRESS> m_gpu_addresses;
 		std::optional<std::vector<std::uint8_t*>> m_cpu_addresses;
-		std::uint64_t m_unaligned_size;
-		std::uint64_t m_begin_offset;
-		std::size_t m_heap_vector_location;
-		std::size_t m_stride;
-		bool m_used_as_uav;
+		std::uint64_t m_unaligned_size = 0u;
+		std::uint64_t m_begin_offset = 0u;
+		std::size_t m_heap_vector_location = 0;
+		std::size_t m_stride = 0;
+		bool m_used_as_uav = false;
 		HeapOptimization m_resource_heap_optimization;
 		std::vector<ResourceState> m_states;
 	};
 
 	struct IndirectCommandBuffer
 	{
-		std::size_t m_num_commands;
-		std::size_t m_num_max_commands;
-		std::size_t m_command_size;
+		std::size_t m_num_commands = 0u;
+		std::size_t m_num_max_commands = 0u;
+		std::size_t m_command_size = 0u;
 		std::vector<ID3D12Resource*> m_native;
 		std::vector<ID3D12Resource*> m_native_upload;
 	};
 
 	struct StateObject
 	{
-		ID3D12StateObject* m_native;
-		RootSignature* m_global_root_signature;
-		ID3D12StateObjectProperties* m_properties;
+		ID3D12StateObject* m_native = nullptr;
+		RootSignature* m_global_root_signature = nullptr;
+		ID3D12StateObjectProperties* m_properties = nullptr;
 
-		ID3D12RaytracingFallbackStateObject* m_fallback_native;
+		ID3D12RaytracingFallbackStateObject* m_fallback_native = nullptr;
 
 		desc::StateObjectDesc m_desc;
-		Device* m_device; // Only for refinalization.
+		Device* m_device = nullptr; // Only for refinalization.
 	};
 
 	struct AccelerationStructure
 	{
-		ID3D12Resource* m_scratch;														 // Scratch memory for AS builder
-		std::array<ID3D12Resource*, d3d12::settings::num_back_buffers> m_natives;        // Where the AS is
-		std::array<ID3D12Resource*, d3d12::settings::num_back_buffers> m_instance_descs; // Hold the matrices of the instances
+		ID3D12Resource* m_scratch = nullptr;														 // Scratch memory for AS builder
+		std::array<ID3D12Resource*, d3d12::settings::num_back_buffers> m_natives = { nullptr };        // Where the AS is
+		std::array<ID3D12Resource*, d3d12::settings::num_back_buffers> m_instance_descs = { nullptr }; // Hold the matrices of the instances
 		WRAPPED_GPU_POINTER m_fallback_tlas_ptr;
 		D3D12_RAYTRACING_ACCELERATION_STRUCTURE_PREBUILD_INFO m_prebuild_info;
 	};
@@ -405,7 +405,7 @@ namespace wr::d3d12
 		struct BlasDesc
 		{
 			d3d12::AccelerationStructure m_as;
-			std::uint64_t m_material;
+			std::uint64_t m_material = 0u;
 			DirectX::XMMATRIX m_transform;
 		};
 	} /* desc */
@@ -418,10 +418,10 @@ namespace wr::d3d12
 
 	struct ShaderTable
 	{
-		std::uint8_t* m_mapped_shader_records;
-		std::uint64_t m_shader_record_size;
+		std::uint8_t* m_mapped_shader_records = nullptr;
+		std::uint64_t m_shader_record_size = 0u;
 		std::vector<ShaderRecord> m_shader_records;
-		ID3D12Resource* m_resource;
+		ID3D12Resource* m_resource = nullptr;
 	};
 
 } /* wr::d3d12 */

--- a/src/d3d12/d3d12_structured_buffer.cpp
+++ b/src/d3d12/d3d12_structured_buffer.cpp
@@ -17,8 +17,8 @@ namespace wr::d3d12
 		srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
 		srv_desc.ViewDimension = D3D12_SRV_DIMENSION_BUFFER;
 		srv_desc.Buffer.FirstElement = 0;
-		srv_desc.Buffer.NumElements = structured_buffer->m_unaligned_size / structured_buffer->m_stride;
-		srv_desc.Buffer.StructureByteStride = structured_buffer->m_stride;
+		srv_desc.Buffer.NumElements = static_cast<UINT>(structured_buffer->m_unaligned_size / structured_buffer->m_stride);
+		srv_desc.Buffer.StructureByteStride = static_cast<UINT>(structured_buffer->m_stride);
 		srv_desc.Buffer.Flags = D3D12_BUFFER_SRV_FLAG_NONE;
 
 		n_device->CreateShaderResourceView(resource, &srv_desc, handle.m_native);

--- a/src/d3d12/d3d12_structured_buffer_pool.cpp
+++ b/src/d3d12/d3d12_structured_buffer_pool.cpp
@@ -33,7 +33,7 @@ namespace wr
 			if (info.m_data.size() > 0)
 			{
 				d3d12::UpdateStructuredBuffer(info.m_buffer_handle->m_native,
-					frame_idx,
+					static_cast<std::uint32_t>(frame_idx),
 					info.m_data.data(),
 					info.m_size,
 					info.m_offset,
@@ -46,11 +46,13 @@ namespace wr
 
 				if (info.m_buffer_handle->m_native->m_states[frame_idx] != info.m_new_state)
 				{
+					CD3DX12_RESOURCE_BARRIER transition_barrier = CD3DX12_RESOURCE_BARRIER::Transition(
+						resource,
+						static_cast<D3D12_RESOURCE_STATES>(info.m_buffer_handle->m_native->m_states[frame_idx]),
+						static_cast<D3D12_RESOURCE_STATES>(info.m_new_state));
+
 					cmd_list->m_native->ResourceBarrier(1,
-						&CD3DX12_RESOURCE_BARRIER::Transition(
-							resource,
-							static_cast<D3D12_RESOURCE_STATES>(info.m_buffer_handle->m_native->m_states[frame_idx]),
-							static_cast<D3D12_RESOURCE_STATES>(info.m_new_state)));
+						&transition_barrier);
 					info.m_buffer_handle->m_native->m_states[frame_idx] = info.m_new_state;
 				}
 				else

--- a/src/d3d12/d3d12_texture_resources.hpp
+++ b/src/d3d12/d3d12_texture_resources.hpp
@@ -13,16 +13,16 @@ namespace wr::d3d12
 {
 	struct TextureResource : Texture
 	{
-		std::size_t m_width;
-		std::size_t m_height;
-		std::size_t m_depth;
-		std::size_t m_array_size;
-		std::size_t m_mip_levels;
+		std::size_t m_width = 0;
+		std::size_t m_height = 0;
+		std::size_t m_depth = 0;
+		std::size_t m_array_size = 0;
+		std::size_t m_mip_levels = 0;
 
-		Format m_format;
+		Format m_format = wr::Format::UNKNOWN;
 
-		ID3D12Resource* m_resource;
-		ID3D12Resource* m_intermediate;
+		ID3D12Resource* m_resource = nullptr;
+		ID3D12Resource* m_intermediate = nullptr;
 		std::vector<ResourceState> m_subresource_states;
 		DescriptorAllocation m_srv_allocation;
 		DescriptorAllocation m_uav_allocation;

--- a/src/d3d12/d3d12_textures.cpp
+++ b/src/d3d12/d3d12_textures.cpp
@@ -26,7 +26,7 @@ namespace wr::d3d12
 		desc.Width = description->m_width;
 		desc.Height = description->m_height;
 		desc.MipLevels = static_cast<std::uint16_t>(description->m_mip_levels);
-		desc.DepthOrArraySize = (description->m_depth > 1) ? description->m_depth : description->m_array_size;
+		desc.DepthOrArraySize = static_cast<UINT16>((description->m_depth > 1) ? description->m_depth : description->m_array_size);
 		desc.Format = static_cast<DXGI_FORMAT>(description->m_texture_format);
 		desc.SampleDesc.Count = 1;
 		desc.SampleDesc.Quality = 0;
@@ -58,6 +58,7 @@ namespace wr::d3d12
 		ID3D12Resource* intermediate;
 
 		CD3DX12_HEAP_PROPERTIES uploadHeapProperties(D3D12_HEAP_TYPE_UPLOAD);
+		CD3DX12_RESOURCE_DESC buffer_desc = CD3DX12_RESOURCE_DESC::Buffer(textureUploadBufferSize);
 
 		device->m_native->CreateCommittedResource(
 			&uploadHeapProperties,
@@ -108,7 +109,7 @@ namespace wr::d3d12
 		desc.Width = description->m_width;
 		desc.Height = description->m_height;
 		desc.MipLevels = static_cast<std::uint16_t>(description->m_mip_levels);
-		desc.DepthOrArraySize = (description->m_depth > 1) ? description->m_depth : description->m_array_size;
+		desc.DepthOrArraySize = static_cast<std::uint16_t>((description->m_depth > 1) ? description->m_depth : description->m_array_size);
 		desc.Format = static_cast<DXGI_FORMAT>(description->m_texture_format);
 		desc.SampleDesc.Count = 1;
 		desc.SampleDesc.Quality = 0;
@@ -173,8 +174,6 @@ namespace wr::d3d12
 
 		tex->m_resource->GetDevice(IID_PPV_ARGS(&n_device));
 
-		unsigned int increment_size = n_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-
 		D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
 		srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
 		srv_desc.Format = (DXGI_FORMAT)tex->m_format;
@@ -185,7 +184,7 @@ namespace wr::d3d12
 		if (tex->m_is_cubemap)
 		{
 			dimension = D3D12_SRV_DIMENSION_TEXTURECUBE;
-			srv_desc.TextureCube.MipLevels = tex->m_mip_levels;
+			srv_desc.TextureCube.MipLevels = static_cast<std::uint32_t>(tex->m_mip_levels);
 		}
 		else
 		{
@@ -193,7 +192,7 @@ namespace wr::d3d12
 			{
 				//Then it's a 3D texture
 				dimension = D3D12_SRV_DIMENSION_TEXTURE3D;
-				srv_desc.Texture3D.MipLevels = tex->m_mip_levels;
+				srv_desc.Texture3D.MipLevels = static_cast<std::uint32_t>(tex->m_mip_levels);
 			}
 			else
 			{
@@ -202,13 +201,13 @@ namespace wr::d3d12
 					if (tex->m_array_size > 1)
 					{
 						dimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
-						srv_desc.Texture2DArray.MipLevels = tex->m_mip_levels;
-						srv_desc.Texture2DArray.ArraySize = tex->m_array_size;
+						srv_desc.Texture2DArray.MipLevels = static_cast<std::uint32_t>(tex->m_mip_levels);
+						srv_desc.Texture2DArray.ArraySize = static_cast<std::uint32_t>(tex->m_array_size);
 					}
 					else
 					{
 						dimension = D3D12_SRV_DIMENSION_TEXTURE2D;
-						srv_desc.Texture2D.MipLevels = tex->m_mip_levels;
+						srv_desc.Texture2D.MipLevels = static_cast<std::uint32_t>(tex->m_mip_levels);
 					}
 				}
 				else
@@ -218,14 +217,14 @@ namespace wr::d3d12
 					{
 						dimension = D3D12_SRV_DIMENSION_TEXTURE1DARRAY;
 
-						srv_desc.Texture1DArray.MipLevels = tex->m_mip_levels;
-						srv_desc.Texture1DArray.ArraySize = tex->m_array_size;
+						srv_desc.Texture1DArray.MipLevels = static_cast<std::uint32_t>(tex->m_mip_levels);
+						srv_desc.Texture1DArray.ArraySize = static_cast<std::uint32_t>(tex->m_array_size);
 					}
 					else
 					{
 						dimension = D3D12_SRV_DIMENSION_TEXTURE1D;
 
-						srv_desc.Texture1D.MipLevels = tex->m_mip_levels;
+						srv_desc.Texture1D.MipLevels = static_cast<std::uint32_t>(tex->m_mip_levels);
 					}
 				}
 			}
@@ -242,8 +241,6 @@ namespace wr::d3d12
 		decltype(Device::m_native) n_device;
 
 		tex->m_resource->GetDevice(IID_PPV_ARGS(&n_device));
-
-		unsigned int increment_size = n_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
 		D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
 		srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
@@ -276,7 +273,7 @@ namespace wr::d3d12
 						dimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
 						srv_desc.Texture2DArray.MipLevels = mip_levels;
 						srv_desc.Texture2DArray.MostDetailedMip = most_detailed_mip;
-						srv_desc.Texture2DArray.ArraySize = tex->m_array_size;
+						srv_desc.Texture2DArray.ArraySize = static_cast<std::uint32_t>(tex->m_array_size);
 					}
 					else
 					{
@@ -294,7 +291,7 @@ namespace wr::d3d12
 
 						srv_desc.Texture1DArray.MipLevels = mip_levels;
 						srv_desc.Texture1DArray.MostDetailedMip = most_detailed_mip;
-						srv_desc.Texture1DArray.ArraySize = tex->m_array_size;
+						srv_desc.Texture1DArray.ArraySize = static_cast<std::uint32_t>(tex->m_array_size);
 					}
 					else
 					{
@@ -318,8 +315,6 @@ namespace wr::d3d12
 		decltype(Device::m_native) n_device;
 
 		tex->m_resource->GetDevice(IID_PPV_ARGS(&n_device));
-
-		unsigned int increment_size = n_device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
 		D3D12_SHADER_RESOURCE_VIEW_DESC srv_desc = {};
 		srv_desc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
@@ -371,7 +366,7 @@ namespace wr::d3d12
 		{
 			dimension = D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
 			uav_desc.Texture2DArray.MipSlice = mip_slice;
-			uav_desc.Texture2DArray.ArraySize = tex->m_array_size;
+			uav_desc.Texture2DArray.ArraySize = static_cast<std::uint32_t>(tex->m_array_size);
 		}
 		else
 		{
@@ -391,7 +386,7 @@ namespace wr::d3d12
 						dimension = D3D12_UAV_DIMENSION_TEXTURE2DARRAY;
 
 						uav_desc.Texture2DArray.MipSlice = mip_slice;
-						uav_desc.Texture2DArray.ArraySize = tex->m_array_size;
+						uav_desc.Texture2DArray.ArraySize = static_cast<std::uint32_t>(tex->m_array_size);
 					}
 					else
 					{
@@ -408,7 +403,7 @@ namespace wr::d3d12
 						dimension = D3D12_UAV_DIMENSION_TEXTURE1DARRAY;
 
 						uav_desc.Texture1DArray.MipSlice = mip_slice;
-						uav_desc.Texture1DArray.ArraySize = tex->m_array_size;
+						uav_desc.Texture1DArray.ArraySize = static_cast<std::uint32_t>(tex->m_array_size);
 					}
 					else
 					{

--- a/src/d3d12/d3d12_textures.cpp
+++ b/src/d3d12/d3d12_textures.cpp
@@ -63,7 +63,7 @@ namespace wr::d3d12
 		device->m_native->CreateCommittedResource(
 			&uploadHeapProperties,
 			D3D12_HEAP_FLAG_NONE,
-			&CD3DX12_RESOURCE_DESC::Buffer(textureUploadBufferSize),
+			&buffer_desc,
 			D3D12_RESOURCE_STATE_GENERIC_READ,
 			nullptr,
 			IID_PPV_ARGS(&intermediate));

--- a/src/frame_graph/frame_graph.hpp
+++ b/src/frame_graph/frame_graph.hpp
@@ -275,8 +275,8 @@ namespace wr
 				if (!m_rt_properties[i].value().m_is_render_window)
 				{
 					render_system.ResizeRenderTarget(&m_render_targets[i],
-						static_cast<std::uint32_t>(width * m_rt_properties[i].value().m_resolution_scale.Get()),
-						static_cast<std::uint32_t>(height * m_rt_properties[i].value().m_resolution_scale.Get()));
+						static_cast<std::uint32_t>(std::ceil(m_rt_properties[i].value().m_resolution_scale.Get() * width)),
+						static_cast<std::uint32_t>(std::ceil(m_rt_properties[i].value().m_resolution_scale.Get() * height)));
 				}
 
 				m_setup_funcs[i](render_system, *this, i, true);

--- a/src/model_pool.hpp
+++ b/src/model_pool.hpp
@@ -50,7 +50,7 @@ namespace wr
 	struct Model
 	{
 		std::vector<std::pair<Mesh*, MaterialHandle>> m_meshes;
-		ModelPool* m_model_pool;
+		ModelPool* m_model_pool = nullptr;
 		std::string m_model_name;
 
 		Box m_box;

--- a/src/render_tasks/d3d12_accumulation.hpp
+++ b/src/render_tasks/d3d12_accumulation.hpp
@@ -63,7 +63,6 @@ namespace wr
 		inline void ExecuteAccumulationTask(RenderSystem& rs, FrameGraph& fg, SceneGraph&, RenderTaskHandle handle)
 		{
 			auto& n_render_system = static_cast<D3D12RenderSystem&>(rs);
-			auto& device = n_render_system.m_device;
 			auto& data = fg.GetData<AccumulationData>(handle);
 			auto frame_idx = n_render_system.GetFrameIdx();
 			auto cmd_list = fg.GetCommandList<d3d12::CommandList>(handle);

--- a/src/render_tasks/d3d12_bloom_composition.hpp
+++ b/src/render_tasks/d3d12_bloom_composition.hpp
@@ -27,15 +27,15 @@ namespace wr
 
 	struct BloomCompostionData
 	{
-		d3d12::RenderTarget* out_source_rt;
-		d3d12::RenderTarget* out_source_bloom_rt;
-		d3d12::PipelineState* out_pipeline;
-		ID3D12Resource* out_previous;
-		DescriptorAllocator* out_allocator;
+		d3d12::RenderTarget* out_source_rt = nullptr;
+		d3d12::RenderTarget* out_source_bloom_rt = nullptr;
+		d3d12::PipelineState* out_pipeline = nullptr;
+		ID3D12Resource* out_previous = nullptr;
+		DescriptorAllocator* out_allocator = nullptr;
 		DescriptorAllocation out_allocation;
 
 		std::shared_ptr<ConstantBufferPool> bloom_cb_pool;
-		D3D12ConstantBufferHandle* cb_handle;
+		D3D12ConstantBufferHandle* cb_handle = nullptr;
 	};
 
 	namespace internal

--- a/src/render_tasks/d3d12_bloom_horizontal.hpp
+++ b/src/render_tasks/d3d12_bloom_horizontal.hpp
@@ -13,10 +13,10 @@ namespace wr
 {
 	struct BloomHData
 	{
-		d3d12::RenderTarget* out_source_rt;
-		d3d12::PipelineState* out_pipeline;
-		ID3D12Resource* out_previous;
-		DescriptorAllocator* out_allocator;
+		d3d12::RenderTarget* out_source_rt = nullptr;
+		d3d12::PipelineState* out_pipeline = nullptr;
+		ID3D12Resource* out_previous = nullptr;
+		DescriptorAllocator* out_allocator = nullptr;
 		DescriptorAllocation out_allocation;
 	};
 

--- a/src/render_tasks/d3d12_bloom_vertical.hpp
+++ b/src/render_tasks/d3d12_bloom_vertical.hpp
@@ -13,10 +13,10 @@ namespace wr
 {
 	struct BloomVData
 	{
-		d3d12::RenderTarget* out_source_rt;
-		d3d12::PipelineState* out_pipeline;
-		ID3D12Resource* out_previous;
-		DescriptorAllocator* out_allocator;
+		d3d12::RenderTarget* out_source_rt = nullptr;
+		d3d12::PipelineState* out_pipeline = nullptr;
+		ID3D12Resource* out_previous = nullptr;
+		DescriptorAllocator* out_allocator = nullptr;
 		DescriptorAllocation out_allocation;
 	};
 

--- a/src/render_tasks/d3d12_build_acceleration_structures.hpp
+++ b/src/render_tasks/d3d12_build_acceleration_structures.hpp
@@ -264,7 +264,7 @@ namespace wr
 					// Create BYTE ADDRESS buffer view into a staging buffer. Hopefully this works.
 					{
 						auto cpu_handle = data.out_scene_ib_alloc.GetDescriptorHandle();
-						d3d12::CreateRawSRVFromStagingBuffer(data.out_scene_ib, cpu_handle, data.out_scene_ib->m_size / data.out_scene_ib->m_stride_in_bytes);
+						d3d12::CreateRawSRVFromStagingBuffer(data.out_scene_ib, cpu_handle, static_cast<std::uint32_t>(data.out_scene_ib->m_size / data.out_scene_ib->m_stride_in_bytes));
 					}
 
 					// Create material structured buffer view

--- a/src/render_tasks/d3d12_cubemap_convolution.hpp
+++ b/src/render_tasks/d3d12_cubemap_convolution.hpp
@@ -156,7 +156,7 @@ namespace wr
 								n_mesh->m_vertex_staging_buffer_stride);
 
 							d3d12::BindIndexBuffer(cmd_list, static_cast<D3D12ModelPool*>(cube_model->m_model_pool)->GetIndexStagingBuffer(),
-								0, model_pool->GetIndexStagingBuffer()->m_size);
+								0, static_cast<std::uint32_t>(model_pool->GetIndexStagingBuffer()->m_size));
 
 							constexpr unsigned int env_idx = rs_layout::GetHeapLoc(params::cubemap_convolution, params::CubemapConvolutionE::ENVIRONMENT_CUBEMAP);
 							d3d12::SetShaderSRV(cmd_list, 2, env_idx, radiance);

--- a/src/render_tasks/d3d12_cubemap_convolution.hpp
+++ b/src/render_tasks/d3d12_cubemap_convolution.hpp
@@ -149,12 +149,14 @@ namespace wr
 						{
 							auto n_mesh = static_cast<D3D12ModelPool*>(cube_model->m_model_pool)->GetMeshData(mesh.first->id);
 
+							D3D12ModelPool* model_pool = static_cast<D3D12ModelPool*>(cube_model->m_model_pool);
+
 							d3d12::BindVertexBuffer(cmd_list, static_cast<D3D12ModelPool*>(cube_model->m_model_pool)->GetVertexStagingBuffer(),
-								0, static_cast<D3D12ModelPool*>(cube_model->m_model_pool)->GetVertexStagingBuffer()->m_size,
+								0, model_pool->GetVertexStagingBuffer()->m_size,
 								n_mesh->m_vertex_staging_buffer_stride);
 
 							d3d12::BindIndexBuffer(cmd_list, static_cast<D3D12ModelPool*>(cube_model->m_model_pool)->GetIndexStagingBuffer(),
-								0, static_cast<D3D12ModelPool*>(cube_model->m_model_pool)->GetIndexStagingBuffer()->m_size);
+								0, model_pool->GetIndexStagingBuffer()->m_size);
 
 							constexpr unsigned int env_idx = rs_layout::GetHeapLoc(params::cubemap_convolution, params::CubemapConvolutionE::ENVIRONMENT_CUBEMAP);
 							d3d12::SetShaderSRV(cmd_list, 2, env_idx, radiance);

--- a/src/render_tasks/d3d12_deferred_composition.cpp
+++ b/src/render_tasks/d3d12_deferred_composition.cpp
@@ -236,9 +236,9 @@ namespace wr
 				// Get HBAO+ Texture
 				if (data.is_hbao)
 				{
-					d3d12::DescHeapCPUHandle handle = data.out_screen_space_ao_alloc.GetDescriptorHandle();
+					d3d12::DescHeapCPUHandle desc_handle = data.out_screen_space_ao_alloc.GetDescriptorHandle();
 					d3d12::RenderTarget* ao_rt = static_cast<d3d12::RenderTarget*>(fg.GetPredecessorRenderTarget<wr::HBAOData>());
-					d3d12::CreateSRVFromSpecificRTV(ao_rt, handle, 0, ao_rt->m_create_info.m_rtv_formats[0]);
+					d3d12::CreateSRVFromSpecificRTV(ao_rt, desc_handle, 0, ao_rt->m_create_info.m_rtv_formats[0]);
 				}
 
 				// Get Irradiance Map

--- a/src/render_tasks/d3d12_deferred_composition.cpp
+++ b/src/render_tasks/d3d12_deferred_composition.cpp
@@ -212,7 +212,7 @@ namespace wr
 
 				//Get light buffer
 				{
-					auto srv_struct_buffer_handle = data.out_lights_alloc.GetDescriptorHandle();
+					d3d12::DescHeapCPUHandle srv_struct_buffer_handle = data.out_lights_alloc.GetDescriptorHandle();
 					d3d12::CreateSRVFromStructuredBuffer(static_cast<D3D12StructuredBufferHandle*>(scene_graph.GetLightBuffer())->m_native, srv_struct_buffer_handle, frame_idx);
 				}
 
@@ -228,16 +228,16 @@ namespace wr
 				// Get Screen Space Environment Texture
 				if (data.is_path_tracer)
 				{
-					auto irradiance_handle = data.out_screen_space_irradiance_alloc.GetDescriptorHandle();
-					auto pred_rt = static_cast<d3d12::RenderTarget*>(fg.GetPredecessorRenderTarget<wr::AccumulationData>());
+					d3d12::DescHeapCPUHandle irradiance_handle = data.out_screen_space_irradiance_alloc.GetDescriptorHandle();
+					d3d12::RenderTarget* pred_rt = static_cast<d3d12::RenderTarget*>(fg.GetPredecessorRenderTarget<wr::AccumulationData>());
 					d3d12::CreateSRVFromSpecificRTV(pred_rt, irradiance_handle, 0, pred_rt->m_create_info.m_rtv_formats[0]);
 				}
 
 				// Get HBAO+ Texture
 				if (data.is_hbao)
 				{
-					auto handle =  data.out_screen_space_ao_alloc.GetDescriptorHandle();
-					auto ao_rt = static_cast<d3d12::RenderTarget*>(fg.GetPredecessorRenderTarget<wr::HBAOData>());
+					d3d12::DescHeapCPUHandle handle = data.out_screen_space_ao_alloc.GetDescriptorHandle();
+					d3d12::RenderTarget* ao_rt = static_cast<d3d12::RenderTarget*>(fg.GetPredecessorRenderTarget<wr::HBAOData>());
 					d3d12::CreateSRVFromSpecificRTV(ao_rt, handle, 0, ao_rt->m_create_info.m_rtv_formats[0]);
 				}
 
@@ -257,7 +257,7 @@ namespace wr
 
 				// Output UAV
 				{
-					auto rtv_out_uav_handle = data.out_output_alloc.GetDescriptorHandle();
+					d3d12::DescHeapCPUHandle rtv_out_uav_handle = data.out_output_alloc.GetDescriptorHandle();
 					std::vector<Format> formats = { Format::R16G16B16A16_FLOAT };
 					d3d12::CreateUAVFromRTV(render_target, rtv_out_uav_handle, 1, formats.data());
 				}

--- a/src/render_tasks/d3d12_deferred_composition.hpp
+++ b/src/render_tasks/d3d12_deferred_composition.hpp
@@ -10,10 +10,10 @@ namespace wr
 {
 	struct DeferredCompositionTaskData
 	{
-		D3D12Pipeline* in_pipeline;
-		d3d12::RenderTarget* out_deferred_main_rt;
+		D3D12Pipeline* in_pipeline = nullptr;
+		d3d12::RenderTarget* out_deferred_main_rt = nullptr;
 
-		DescriptorAllocator* out_allocator;
+		DescriptorAllocator* out_allocator = nullptr;
 
 		DescriptorAllocation out_gbuffer_albedo_alloc;
 		DescriptorAllocation out_gbuffer_normal_alloc;
@@ -25,17 +25,17 @@ namespace wr
 		DescriptorAllocation out_screen_space_ao_alloc;
 		DescriptorAllocation out_output_alloc;
 
-		d3d12::TextureResource* out_skybox;
-		d3d12::TextureResource* out_irradiance;
-		d3d12::TextureResource* out_pref_env_map;
+		d3d12::TextureResource* out_skybox = nullptr;
+		d3d12::TextureResource* out_irradiance = nullptr;
+		d3d12::TextureResource* out_pref_env_map = nullptr;
 
-		std::array<d3d12::CommandList*, d3d12::settings::num_back_buffers> out_bundle_cmd_lists;
-		bool out_requires_bundle_recording;
+		std::array<d3d12::CommandList*, d3d12::settings::num_back_buffers> out_bundle_cmd_lists = {};
+		bool out_requires_bundle_recording = false;
 
-		bool is_hybrid;
-		bool is_path_tracer;
-		bool is_rtao;
-		bool is_hbao;
+		bool is_hybrid = false;
+		bool is_path_tracer = false;
+		bool is_rtao = false;
+		bool is_hbao = false;
 	};
 
 	namespace internal

--- a/src/render_tasks/d3d12_dof_bokeh.hpp
+++ b/src/render_tasks/d3d12_dof_bokeh.hpp
@@ -13,15 +13,15 @@ namespace wr
 {
 	struct DoFBokehData
 	{
-		d3d12::RenderTarget* out_source_rt;
-		d3d12::RenderTarget* out_source_coc_rt;
-		d3d12::PipelineState* out_pipeline;
-		ID3D12Resource* out_previous;
-		DescriptorAllocator* out_allocator;
+		d3d12::RenderTarget* out_source_rt = nullptr;
+		d3d12::RenderTarget* out_source_coc_rt = nullptr;
+		d3d12::PipelineState* out_pipeline = nullptr;
+		ID3D12Resource* out_previous = nullptr;
+		DescriptorAllocator* out_allocator = nullptr;
 		DescriptorAllocation out_allocation;
 
 		std::shared_ptr<ConstantBufferPool> camera_cb_pool;
-		D3D12ConstantBufferHandle* cb_handle;
+		D3D12ConstantBufferHandle* cb_handle = nullptr;
 	};
 
 	namespace internal
@@ -29,11 +29,11 @@ namespace wr
 
 		struct Bokeh_CB
 		{
-			float m_f_number;
-			float m_shape;
-			float m_bokeh_poly;
-			uint32_t m_blades;
-			int m_enable_dof;
+			float m_f_number = 0.0f;
+			float m_shape = 0.0f;
+			float m_bokeh_poly = 0.0f;
+			uint32_t m_blades = 0u;
+			int m_enable_dof = false;
 		};
 
 		template<typename T, typename T1>

--- a/src/render_tasks/d3d12_dof_bokeh_postfilter.hpp
+++ b/src/render_tasks/d3d12_dof_bokeh_postfilter.hpp
@@ -12,10 +12,10 @@ namespace wr
 {
 	struct DoFBokehPostFilterData
 	{
-		d3d12::RenderTarget* out_source_rt;
-		d3d12::PipelineState* out_pipeline;
-		ID3D12Resource* out_previous;
-		DescriptorAllocator* out_allocator;
+		d3d12::RenderTarget* out_source_rt = nullptr;
+		d3d12::PipelineState* out_pipeline = nullptr;
+		ID3D12Resource* out_previous = nullptr;
+		DescriptorAllocator* out_allocator = nullptr;
 		DescriptorAllocation out_allocation;
 	};
 

--- a/src/render_tasks/d3d12_dof_coc.hpp
+++ b/src/render_tasks/d3d12_dof_coc.hpp
@@ -28,7 +28,7 @@ namespace wr
 	{
 		struct DoFProperties_CB
 		{
-			DirectX::XMMATRIX m_projection;
+			DirectX::XMMATRIX m_projection = DirectX::XMMatrixIdentity();
 			float m_focal_length = 0.0f;
 			float m_f_number = 0.0f;
 			float m_film_size = 0.0f;

--- a/src/render_tasks/d3d12_dof_coc.hpp
+++ b/src/render_tasks/d3d12_dof_coc.hpp
@@ -13,14 +13,14 @@ namespace wr
 {
 	struct DoFCoCData
 	{
-		d3d12::RenderTarget* out_source_dsv;
-		d3d12::PipelineState* out_pipeline;
-		ID3D12Resource* out_previous;
+		d3d12::RenderTarget* out_source_dsv = nullptr;
+		d3d12::PipelineState* out_pipeline = nullptr;
+		ID3D12Resource* out_previous = nullptr;
 
 		std::shared_ptr<ConstantBufferPool> camera_cb_pool;
-		D3D12ConstantBufferHandle* cb_handle;
+		D3D12ConstantBufferHandle* cb_handle = nullptr;
 
-		DescriptorAllocator* out_allocator;
+		DescriptorAllocator* out_allocator = nullptr;
 		DescriptorAllocation out_allocation;
 	};
 
@@ -29,12 +29,11 @@ namespace wr
 		struct DoFProperties_CB
 		{
 			DirectX::XMMATRIX m_projection;
-			float m_focal_length;
-			float m_f_number;
-			float m_film_size;
-			float m_focus_dist;
-			int m_enable_dof;
-			//uint32_t m_blades;
+			float m_focal_length = 0.0f;
+			float m_f_number = 0.0f;
+			float m_film_size = 0.0f;
+			float m_focus_dist = 0.0f;
+			int m_enable_dof = 0;
 		};
 
 		template<typename T>

--- a/src/render_tasks/d3d12_dof_composition.hpp
+++ b/src/render_tasks/d3d12_dof_composition.hpp
@@ -15,12 +15,12 @@ namespace wr
 {
 	struct DoFCompositionData
 	{
-		d3d12::RenderTarget* out_source_rt_comp;
-		d3d12::RenderTarget* out_source_bokeh_filtered;
-		d3d12::RenderTarget* out_source_coc;
-		d3d12::PipelineState* out_pipeline;
-		ID3D12Resource* out_previous;
-		DescriptorAllocator* out_allocator;
+		d3d12::RenderTarget* out_source_rt_comp = nullptr;
+		d3d12::RenderTarget* out_source_bokeh_filtered = nullptr;
+		d3d12::RenderTarget* out_source_coc = nullptr;
+		d3d12::PipelineState* out_pipeline = nullptr;
+		ID3D12Resource* out_previous = nullptr;
+		DescriptorAllocator* out_allocator = nullptr;
 		DescriptorAllocation out_allocation;
 	};
 

--- a/src/render_tasks/d3d12_dof_dilate_flatten.hpp
+++ b/src/render_tasks/d3d12_dof_dilate_flatten.hpp
@@ -13,11 +13,11 @@ namespace wr
 {
 	struct DoFDilateFlattenData
 	{
-		d3d12::RenderTarget* out_source_rt;
-		d3d12::RenderTarget* out_source_coc_rt;
-		d3d12::PipelineState* out_pipeline;
-		ID3D12Resource* out_previous;
-		DescriptorAllocator* out_allocator;
+		d3d12::RenderTarget* out_source_rt = nullptr;
+		d3d12::RenderTarget* out_source_coc_rt = nullptr;
+		d3d12::PipelineState* out_pipeline = nullptr;
+		ID3D12Resource* out_previous = nullptr;
+		DescriptorAllocator* out_allocator = nullptr;
 		DescriptorAllocation out_allocation;
 	};
 

--- a/src/render_tasks/d3d12_dof_dilate_flatten_second_pass.hpp
+++ b/src/render_tasks/d3d12_dof_dilate_flatten_second_pass.hpp
@@ -13,11 +13,11 @@ namespace wr
 {
 	struct DoFDilateFlattenHData
 	{
-		d3d12::RenderTarget* out_source_rt;
-		d3d12::RenderTarget* out_source_coc_rt;
-		d3d12::PipelineState* out_pipeline;
-		ID3D12Resource* out_previous;
-		DescriptorAllocator* out_allocator;
+		d3d12::RenderTarget* out_source_rt = nullptr;
+		d3d12::RenderTarget* out_source_coc_rt = nullptr;
+		d3d12::PipelineState* out_pipeline = nullptr;
+		ID3D12Resource* out_previous = nullptr;
+		DescriptorAllocator* out_allocator = nullptr;
 		DescriptorAllocation out_allocation;
 	};
 

--- a/src/render_tasks/d3d12_dof_dilate_near.hpp
+++ b/src/render_tasks/d3d12_dof_dilate_near.hpp
@@ -13,7 +13,7 @@ namespace wr
 {
 	struct DoFDilateData
 	{
-		d3d12::RenderTarget* out_source_rt;
+		d3d12::RenderTarget* out_source_rt = nullptr;
 		d3d12::RenderTarget* out_source_coc_rt;
 		d3d12::PipelineState* out_pipeline;
 		ID3D12Resource* out_previous;

--- a/src/render_tasks/d3d12_dof_dilate_near.hpp
+++ b/src/render_tasks/d3d12_dof_dilate_near.hpp
@@ -14,10 +14,10 @@ namespace wr
 	struct DoFDilateData
 	{
 		d3d12::RenderTarget* out_source_rt = nullptr;
-		d3d12::RenderTarget* out_source_coc_rt;
-		d3d12::PipelineState* out_pipeline;
-		ID3D12Resource* out_previous;
-		DescriptorAllocator* out_allocator;
+		d3d12::RenderTarget* out_source_coc_rt = nullptr;
+		d3d12::PipelineState* out_pipeline = nullptr;
+		ID3D12Resource* out_previous = nullptr;
+		DescriptorAllocator* out_allocator = nullptr;
 		DescriptorAllocation out_allocation;
 	};
 

--- a/src/render_tasks/d3d12_down_scale.hpp
+++ b/src/render_tasks/d3d12_down_scale.hpp
@@ -13,11 +13,11 @@ namespace wr
 {
 	struct DownScaleData
 	{
-		d3d12::RenderTarget* out_source_rt;
-		d3d12::RenderTarget* out_source_coc;
-		d3d12::PipelineState* out_pipeline;
-		ID3D12Resource* out_previous;
-		DescriptorAllocator* out_allocator;
+		d3d12::RenderTarget* out_source_rt = nullptr;
+		d3d12::RenderTarget* out_source_coc = nullptr;
+		d3d12::PipelineState* out_pipeline = nullptr;
+		ID3D12Resource* out_previous = nullptr;
+		DescriptorAllocator* out_allocator = nullptr;
 		DescriptorAllocation out_allocation;
 	};
 

--- a/src/render_tasks/d3d12_equirect_to_cubemap.hpp
+++ b/src/render_tasks/d3d12_equirect_to_cubemap.hpp
@@ -231,7 +231,7 @@ namespace wr
 
 						d3d12::BindVertexBuffer(cmd_list, pool->GetVertexStagingBuffer(), 0, pool->GetVertexStagingBuffer()->m_size, n_mesh->m_vertex_staging_buffer_stride);
 
-						d3d12::BindIndexBuffer(cmd_list, pool->GetIndexStagingBuffer(), 0, pool->GetIndexStagingBuffer()->m_size);
+						d3d12::BindIndexBuffer(cmd_list, pool->GetIndexStagingBuffer(), 0, static_cast<std::uint32_t>(pool->GetIndexStagingBuffer()->m_size));
 
 						constexpr unsigned int srv_idx = rs_layout::GetHeapLoc(params::cubemap_conversion, params::CubemapConversionE::EQUIRECTANGULAR_TEXTURE);
 						d3d12::SetShaderSRV(cmd_list, 2, srv_idx, equirect_text);

--- a/src/render_tasks/d3d12_hbao.hpp
+++ b/src/render_tasks/d3d12_hbao.hpp
@@ -39,11 +39,11 @@ namespace wr
 		GFSDK_SSAO_InputData_D3D12 ssao_input_data;
 #endif
 
-		d3d12::DescHeapCPUHandle cpu_depth_handle;
-		d3d12::DescHeapGPUHandle gpu_depth_handle;
-		d3d12::DescHeapCPUHandle cpu_normal_handle;
-		d3d12::DescHeapGPUHandle gpu_normal_handle;
-		d3d12::DescHeapCPUHandle cpu_target_handle;
+		d3d12::DescHeapCPUHandle cpu_depth_handle = d3d12::DescHeapCPUHandle();
+		d3d12::DescHeapGPUHandle gpu_depth_handle = d3d12::DescHeapGPUHandle();
+		d3d12::DescHeapCPUHandle cpu_normal_handle = d3d12::DescHeapCPUHandle();
+		d3d12::DescHeapGPUHandle gpu_normal_handle = d3d12::DescHeapGPUHandle();
+		d3d12::DescHeapCPUHandle cpu_target_handle = d3d12::DescHeapCPUHandle();
 	};
 
 	namespace internal

--- a/src/render_tasks/d3d12_path_tracer.hpp
+++ b/src/render_tasks/d3d12_path_tracer.hpp
@@ -16,6 +16,7 @@
 
 namespace wr
 {
+	//TODO, this struct is unpadded, manual padding might be usefull.
 	struct PathTracerData
 	{
 		d3d12::AccelerationStructure out_tlas = {};

--- a/src/render_tasks/d3d12_raytracing_task.hpp
+++ b/src/render_tasks/d3d12_raytracing_task.hpp
@@ -156,6 +156,7 @@ namespace wr
 			auto& as_build_data = fg.GetPredecessorData<wr::ASBuildData>();
 			fg.WaitForPredecessorTask<CubemapConvolutionTaskData>();
 			auto frame_idx = n_render_system.GetFrameIdx();
+			float scalar = 1.0f;
 
 			// Rebuild acceleratrion structure a 2e time for fallback
 			if (d3d12::GetRaytracingType(device) == RaytracingType::FALLBACK)
@@ -307,8 +308,16 @@ namespace wr
 //#ifdef _DEBUG
 				CreateShaderTables(device, data, frame_idx);
 //#endif
+				scalar = fg.GetRenderTargetResolutionScale(handle);
 
-				d3d12::DispatchRays(cmd_list, data.out_hitgroup_shader_table[frame_idx], data.out_miss_shader_table[frame_idx], data.out_raygen_shader_table[frame_idx], window->GetWidth(), window->GetHeight(), 1, 0);
+				d3d12::DispatchRays(cmd_list,
+					data.out_hitgroup_shader_table[frame_idx], 
+					data.out_miss_shader_table[frame_idx], 
+					data.out_raygen_shader_table[frame_idx], 
+					static_cast<std::uint32_t>(std::ceil(scalar * window->GetWidth())), 
+					static_cast<std::uint32_t>(std::ceil(scalar * window->GetHeight())), 
+					1, 
+					0);
 			}
 		}
 

--- a/src/render_tasks/d3d12_raytracing_task.hpp
+++ b/src/render_tasks/d3d12_raytracing_task.hpp
@@ -26,13 +26,13 @@ namespace wr
 		std::array<d3d12::ShaderTable*, d3d12::settings::num_back_buffers> out_raygen_shader_table = { nullptr, nullptr, nullptr };
 		std::array<d3d12::ShaderTable*, d3d12::settings::num_back_buffers> out_miss_shader_table = { nullptr, nullptr, nullptr };
 		std::array<d3d12::ShaderTable*, d3d12::settings::num_back_buffers> out_hitgroup_shader_table = { nullptr, nullptr, nullptr };
-		d3d12::StateObject* out_state_object;
-		d3d12::RootSignature* out_root_signature;
-		D3D12ConstantBufferHandle* out_cb_camera_handle;
+		d3d12::StateObject* out_state_object = nullptr;
+		d3d12::RootSignature* out_root_signature = nullptr;
+		D3D12ConstantBufferHandle* out_cb_camera_handle = nullptr;
 
 		DescriptorAllocation out_uav_from_rtv;
 
-		bool tlas_requires_init;
+		bool tlas_requires_init = false;
 	};
 
 	namespace internal

--- a/src/render_tasks/d3d12_rt_hybrid_task.hpp
+++ b/src/render_tasks/d3d12_rt_hybrid_task.hpp
@@ -372,8 +372,8 @@ namespace wr
 					data.out_hitgroup_shader_table[frame_idx], 
 					data.out_miss_shader_table[frame_idx],
 					data.out_raygen_shader_table[frame_idx], 
-					static_cast<std::uint32_t>(window->GetWidth() * scalar),
-					static_cast<std::uint32_t>(window->GetHeight() * scalar),
+					static_cast<std::uint32_t>(std::ceil(scalar * window->GetWidth())),
+					static_cast<std::uint32_t>(std::ceil(scalar * window->GetHeight())),
 					1u,
 					frame_idx);
 

--- a/src/render_tasks/d3d12_rt_hybrid_task.hpp
+++ b/src/render_tasks/d3d12_rt_hybrid_task.hpp
@@ -372,9 +372,9 @@ namespace wr
 					data.out_hitgroup_shader_table[frame_idx], 
 					data.out_miss_shader_table[frame_idx],
 					data.out_raygen_shader_table[frame_idx], 
-					window->GetWidth() * scalar,
-					window->GetHeight() * scalar,
-					1,
+					static_cast<std::uint32_t>(window->GetWidth() * scalar),
+					static_cast<std::uint32_t>(window->GetHeight() * scalar),
+					1u,
 					frame_idx);
 
 				// Transition depth back to DEPTH_WRITE
@@ -384,10 +384,12 @@ namespace wr
 
 		inline void DestroyRTHybridTask(FrameGraph& fg, RenderTaskHandle handle, bool resize)
 		{
-			auto& data = fg.GetData<RTHybridData>(handle);
+			
 
 			if (!resize)
 			{
+				auto& data = fg.GetData<RTHybridData>(handle);
+
 				// Small hack to force the allocations to go out of scope, which will tell the allocator to free them
 				std::move(data.out_output_alloc);
 				std::move(data.out_gbuffer_albedo_alloc);

--- a/src/render_tasks/d3d12_rtao_task.hpp
+++ b/src/render_tasks/d3d12_rtao_task.hpp
@@ -183,6 +183,7 @@ namespace wr
 			auto frame_idx = n_render_system.GetFrameIdx();
 			auto setting = fg.GetSettings<RTAOData, RTAOSettings>();
 			fg.WaitForPredecessorTask<CubemapConvolutionTaskData>();
+			float scalar = 1.0f;
 
 			if (fg.HasTask<wr::RTHybridData>())
 			{
@@ -238,8 +239,17 @@ namespace wr
 				CreateShaderTables(device, data, frame_idx);
 #endif // _DEBUG
 
+				scalar = fg.GetRenderTargetResolutionScale(handle);
+
 				// Dispatch hybrid ray tracing rays
-				d3d12::DispatchRays(cmd_list, data.in_hitgroup_shader_table[frame_idx], data.in_miss_shader_table[frame_idx], data.in_raygen_shader_table[frame_idx], window->GetWidth(), window->GetHeight(), 1, frame_idx);
+				d3d12::DispatchRays(cmd_list, 
+					data.in_hitgroup_shader_table[frame_idx], 
+					data.in_miss_shader_table[frame_idx], 
+					data.in_raygen_shader_table[frame_idx], 
+					static_cast<std::uint32_t>(std::ceil(scalar * window->GetWidth())),
+					static_cast<std::uint32_t>(std::ceil(scalar * window->GetHeight())),
+					1,
+					frame_idx);
 
 				// Transition depth back to DEPTH_WRITE
 				d3d12::TransitionDepth(cmd_list, data.in_deferred_main_rt, ResourceState::NON_PIXEL_SHADER_RESOURCE, ResourceState::DEPTH_WRITE);

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -82,8 +82,8 @@ namespace wr
 		HWND m_handle;
 		HINSTANCE m_instance;
 
-		uint32_t m_window_width = 0;
-		uint32_t m_window_height = 0;
+		int m_window_width = 0;
+		int m_window_height = 0;
 	};
 
 } /* wr */

--- a/src/window.hpp
+++ b/src/window.hpp
@@ -82,8 +82,8 @@ namespace wr
 		HWND m_handle;
 		HINSTANCE m_instance;
 
-		int m_window_width = 0;
-		int m_window_height = 0;
+		std::int32_t m_window_width = 0;
+		std::int32_t m_window_height = 0;
 	};
 
 } /* wr */


### PR DESCRIPTION
* Reduced almost all warnings, there are still some [nodiscard] warnings and templating warnings that seemingly cant be fixed without breaking the project. 
* Changed order of multiplication to explicitly use proper format for scaling resolution (for safety)