### PR TITLE
Switched the registries to C++20's designated initializers.

### DIFF
--- a/src/d3d12/d3d12_renderer.hpp
+++ b/src/d3d12/d3d12_renderer.hpp
@@ -128,6 +128,10 @@ namespace wr
 		void ReloadRTPipelineRegistryEntry(RegistryHandle handle);
 		void ReloadShaderRegistryEntry(RegistryHandle handle);
 		void ReloadRootSignatureRegistryEntry(RegistryHandle handle);
+		void DestroyRootSignatureRegistry();
+		void DestroyShaderRegistry();
+		void DestroyPipelineRegistry();
+		void DestroyRTPipelineRegistry();
 
 		void WaitForAllPreviousWork();
 

--- a/src/engine_registry.cpp
+++ b/src/engine_registry.cpp
@@ -31,11 +31,11 @@ namespace wr
 		);
 
 	REGISTER(root_signatures::brdf_lut, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(ranges_brdf, D3D12_SHADER_VISIBILITY_ALL)
-		}),
-		RootSignatureDescription::Samplers({ })
-		});
+		},
+		.m_samplers = { }
+	});
 
 
 	//Basic Deferred Pass Root Signature
@@ -49,16 +49,16 @@ namespace wr
 	);
 
 	REGISTER(root_signatures::basic, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM(GetCBV(params::basic, params::BasicE::CAMERA_PROPERTIES, D3D12_SHADER_VISIBILITY_VERTEX)),
 			ROOT_PARAM(GetCBV(params::basic, params::BasicE::OBJECT_PROPERTIES, D3D12_SHADER_VISIBILITY_VERTEX)),
 			ROOT_PARAM_DESC_TABLE(ranges_basic, D3D12_SHADER_VISIBILITY_PIXEL),
 			ROOT_PARAM(GetCBV(params::basic, params::BasicE::MATERIAL_PROPERTIES, D3D12_SHADER_VISIBILITY_PIXEL)),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_WRAP }
-		})
-		});
+		}
+	});
 
 	//Deferred Composition Root Signature
 	DESC_RANGE_ARRAY(srv_ranges,
@@ -75,33 +75,33 @@ namespace wr
 		DESC_RANGE(params::deferred_composition, Type::SRV_RANGE, params::DeferredCompositionE::BUFFER_SCREEN_SPACE_IRRADIANCE),
 		DESC_RANGE(params::deferred_composition, Type::SRV_RANGE, params::DeferredCompositionE::BUFFER_AO),
 		DESC_RANGE(params::deferred_composition, Type::UAV_RANGE, params::DeferredCompositionE::OUTPUT),
-		);
+	);
 
 	REGISTER(root_signatures::deferred_composition, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM(GetCBV(params::deferred_composition, params::DeferredCompositionE::CAMERA_PROPERTIES)),
 			ROOT_PARAM_DESC_TABLE(srv_ranges, D3D12_SHADER_VISIBILITY_ALL),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_POINT, TextureAddressMode::TAM_CLAMP },
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_CLAMP }
-		})
-		});
+		}
+	});
 
 	//MipMapping Root Signature
 	DESC_RANGE_ARRAY(mip_in_out_ranges,
 		DESC_RANGE(params::mip_mapping, Type::SRV_RANGE, params::MipMappingE::SOURCE),
 		DESC_RANGE(params::mip_mapping, Type::UAV_RANGE, params::MipMappingE::DEST),
-		);
+	);
 	REGISTER(root_signatures::mip_mapping, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM(GetConstants(params::mip_mapping, params::MipMappingE::CBUFFER)),
 			ROOT_PARAM_DESC_TABLE(mip_in_out_ranges, D3D12_SHADER_VISIBILITY_ALL)
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_CLAMP }
-		})
-		});
+		}
+	});
 
 	//Prefiltering Root Signature
 	DESC_RANGE_ARRAY(prefilter_in_out_ranges,
@@ -109,14 +109,14 @@ namespace wr
 		DESC_RANGE(params::cubemap_prefiltering, Type::UAV_RANGE, params::CubemapPrefilteringE::DEST),
 		);
 	REGISTER(root_signatures::cubemap_prefiltering, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM(GetConstants(params::cubemap_prefiltering, params::CubemapPrefilteringE::CBUFFER)),
 			ROOT_PARAM_DESC_TABLE(prefilter_in_out_ranges, D3D12_SHADER_VISIBILITY_ALL)
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_CLAMP }
-		})
-		});
+		}
+	});
 
 
 	//Cubemap conversion root signature
@@ -124,235 +124,233 @@ namespace wr
 		DESC_RANGE(params::cubemap_conversion, Type::SRV_RANGE, params::CubemapConversionE::EQUIRECTANGULAR_TEXTURE),
 		);
 	REGISTER(root_signatures::cubemap_conversion, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM(GetConstants(params::cubemap_conversion, params::CubemapConversionE::IDX)),
 			ROOT_PARAM(GetCBV(params::cubemap_conversion, params::CubemapConversionE::CAMERA_PROPERTIES)),
 			ROOT_PARAM_DESC_TABLE(cubemap_tasks_ranges, D3D12_SHADER_VISIBILITY_PIXEL),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_CLAMP }
-		})
-		});
+		}
+	});
 
 	//Cubemap convolution root signature
 	DESC_RANGE_ARRAY(cubemap_convolution_ranges,
 		DESC_RANGE(params::cubemap_conversion, Type::SRV_RANGE, params::CubemapConvolutionE::ENVIRONMENT_CUBEMAP),
 		);
 	REGISTER(root_signatures::cubemap_convolution, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM(GetConstants(params::cubemap_convolution, params::CubemapConvolutionE::IDX)),
 			ROOT_PARAM(GetCBV(params::cubemap_convolution, params::CubemapConvolutionE::CAMERA_PROPERTIES)),
 			ROOT_PARAM_DESC_TABLE(cubemap_tasks_ranges, D3D12_SHADER_VISIBILITY_PIXEL),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_CLAMP }
-		})
-		});
+		}
+	});
 
 
 	REGISTER(shaders::brdf_lut_cs, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/brdf_lut_cs.hlsl"),
-		ShaderDescription::Entry("main_cs"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/brdf_lut_cs.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	REGISTER(shaders::basic_vs, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/basic.hlsl"),
-		ShaderDescription::Entry("main_vs"),
-		ShaderDescription::Type(ShaderType::VERTEX_SHADER)
-		});
+		.path = "resources/shaders/basic.hlsl",
+		.entry = "main_vs",
+		.type = ShaderType::VERTEX_SHADER
+	});
 
 	REGISTER(shaders::basic_ps, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/basic.hlsl"),
-		ShaderDescription::Entry("main_ps"),
-		ShaderDescription::Type(ShaderType::PIXEL_SHADER)
-		});
+		.path = "resources/shaders/basic.hlsl",
+		.entry = "main_ps",
+		.type = ShaderType::PIXEL_SHADER
+	});
 
 	REGISTER(shaders::fullscreen_quad_vs, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/fullscreen_quad.hlsl"),
-		ShaderDescription::Entry("main_vs"),
-		ShaderDescription::Type(ShaderType::VERTEX_SHADER)
-		});
+		.path = "resources/shaders/fullscreen_quad.hlsl",
+		.entry = "main_vs",
+		.type = ShaderType::VERTEX_SHADER
+	});
 
 	REGISTER(shaders::deferred_composition_cs, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/deferred_composition.hlsl"),
-		ShaderDescription::Entry("main_cs"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/deferred_composition.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	REGISTER(shaders::mip_mapping_cs, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/generate_mips_cs.hlsl"),
-		ShaderDescription::Entry("main"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/generate_mips_cs.hlsl",
+		.entry = "main",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	REGISTER(shaders::equirect_to_cubemap_vs, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/equirect_to_cubemap_conversion.hlsl"),
-		ShaderDescription::Entry("main_vs"),
-		ShaderDescription::Type(ShaderType::VERTEX_SHADER)
-		});
+		.path = "resources/shaders/equirect_to_cubemap_conversion.hlsl",
+		.entry = "main_vs",
+		.type = ShaderType::VERTEX_SHADER
+	});
 
 	REGISTER(shaders::equirect_to_cubemap_ps, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/equirect_to_cubemap_conversion.hlsl"),
-		ShaderDescription::Entry("main_ps"),
-		ShaderDescription::Type(ShaderType::PIXEL_SHADER)
-		});
+		.path = "resources/shaders/equirect_to_cubemap_conversion.hlsl",
+		.entry = "main_ps",
+		.type = ShaderType::PIXEL_SHADER
+	});
 
 	REGISTER(shaders::cubemap_convolution_ps, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/cubemap_convolution.hlsl"),
-		ShaderDescription::Entry("main_ps"),
-		ShaderDescription::Type(ShaderType::PIXEL_SHADER)
-		});
+		.path = "resources/shaders/cubemap_convolution.hlsl",
+		.entry = "main_ps",
+		.type = ShaderType::PIXEL_SHADER
+	});
 
 	REGISTER(shaders::cubemap_prefiltering_cs, ShaderRegistry)({
-	ShaderDescription::Path("resources/shaders/prefilter_env_map_cs.hlsl"),
-	ShaderDescription::Entry("main_cs"),
-	ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/prefilter_env_map_cs.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	REGISTER(pipelines::brdf_lut_precalculation, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::brdf_lut_cs),
-		PipelineDescription::RootSignature(root_signatures::brdf_lut),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ Format::R16G16_FLOAT }),
-		PipelineDescription::NumRTVFormats(1),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		}
-	);
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::brdf_lut_cs,
+		.m_root_signature_handle = root_signatures::brdf_lut,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { Format::R16G16_FLOAT },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	REGISTER(pipelines::basic_deferred, PipelineRegistry) < VertexColor > ({
-		PipelineDescription::VertexShader(shaders::basic_vs),
-		PipelineDescription::PixelShader(shaders::basic_ps),
-		PipelineDescription::ComputeShader(std::nullopt),
-		PipelineDescription::RootSignature(root_signatures::basic),
-		PipelineDescription::DSVFormat(Format::D32_FLOAT),
-		PipelineDescription::RTVFormats({ Format::R16G16B16A16_FLOAT, Format::R16G16B16A16_FLOAT, Format::R8G8B8A8_UNORM }),
-		PipelineDescription::NumRTVFormats(3),
-		PipelineDescription::Type(PipelineType::GRAPHICS_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_NONE),
-		PipelineDescription::Depth(true),
-		PipelineDescription::CounterClockwise(false),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = shaders::basic_vs,
+		.m_pixel_shader_handle = shaders::basic_ps,
+		.m_compute_shader_handle = std::nullopt,
+		.m_root_signature_handle = root_signatures::basic,
+		.m_dsv_format = Format::D32_FLOAT,
+		.m_rtv_formats = { Format::R16G16B16A16_FLOAT, Format::R16G16B16A16_FLOAT, Format::R8G8B8A8_UNORM },
+		.m_num_rtv_formats = 3,
+		.m_type = PipelineType::GRAPHICS_PIPELINE,
+		.m_cull_mode = CullMode::CULL_NONE,
+		.m_depth_enabled = true,
+		.m_counter_clockwise = false,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	REGISTER(pipelines::deferred_composition, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::deferred_composition_cs),
-		PipelineDescription::RootSignature(root_signatures::deferred_composition),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ wr::Format::R16G16B16A16_FLOAT }),
-		PipelineDescription::NumRTVFormats(1),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::deferred_composition_cs,
+		.m_root_signature_handle = root_signatures::deferred_composition,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { wr::Format::R16G16B16A16_FLOAT },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	REGISTER(pipelines::mip_mapping, PipelineRegistry) < VertexColor > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::mip_mapping_cs),
-		PipelineDescription::RootSignature(root_signatures::mip_mapping),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ }),
-		PipelineDescription::NumRTVFormats(0),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::mip_mapping_cs,
+		.m_root_signature_handle = root_signatures::mip_mapping,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { },
+		.m_num_rtv_formats = 0,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	REGISTER(pipelines::equirect_to_cubemap, PipelineRegistry) < Vertex > (
-		{
-			PipelineDescription::VertexShader(shaders::equirect_to_cubemap_vs),
-			PipelineDescription::PixelShader(shaders::equirect_to_cubemap_ps),
-			PipelineDescription::ComputeShader(std::nullopt),
-			PipelineDescription::RootSignature(root_signatures::cubemap_conversion),
-			PipelineDescription::DSVFormat(Format::UNKNOWN),
-			PipelineDescription::RTVFormats({ wr::Format::R16G16B16A16_FLOAT }),
-			PipelineDescription::NumRTVFormats(1),
-			PipelineDescription::Type(PipelineType::GRAPHICS_PIPELINE),
-			PipelineDescription::CullMode(CullMode::CULL_NONE),
-			PipelineDescription::Depth(false),
-			PipelineDescription::CounterClockwise(false),
-			PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+	{
+		.m_vertex_shader_handle = shaders::equirect_to_cubemap_vs,
+		.m_pixel_shader_handle = shaders::equirect_to_cubemap_ps,
+		.m_compute_shader_handle = std::nullopt,
+		.m_root_signature_handle = root_signatures::cubemap_conversion,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { wr::Format::R16G16B16A16_FLOAT },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::GRAPHICS_PIPELINE,
+		.m_cull_mode = CullMode::CULL_NONE,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = false,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	REGISTER(pipelines::cubemap_convolution, PipelineRegistry) < Vertex > (
-		{
-			PipelineDescription::VertexShader(shaders::equirect_to_cubemap_vs),
-			PipelineDescription::PixelShader(shaders::cubemap_convolution_ps),
-			PipelineDescription::ComputeShader(std::nullopt),
-			PipelineDescription::RootSignature(root_signatures::cubemap_convolution),
-			PipelineDescription::DSVFormat(Format::UNKNOWN),
-			PipelineDescription::RTVFormats({ wr::Format::R16G16B16A16_FLOAT }),
-			PipelineDescription::NumRTVFormats(1),
-			PipelineDescription::Type(PipelineType::GRAPHICS_PIPELINE),
-			PipelineDescription::CullMode(CullMode::CULL_NONE),
-			PipelineDescription::Depth(false),
-			PipelineDescription::CounterClockwise(false),
-			PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+	{
+		.m_vertex_shader_handle = shaders::equirect_to_cubemap_vs,
+		.m_pixel_shader_handle = shaders::cubemap_convolution_ps,
+		.m_compute_shader_handle = std::nullopt,
+		.m_root_signature_handle = root_signatures::cubemap_convolution,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { wr::Format::R16G16B16A16_FLOAT },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::GRAPHICS_PIPELINE,
+		.m_cull_mode = CullMode::CULL_NONE,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = false,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	REGISTER(pipelines::cubemap_prefiltering, PipelineRegistry) < Vertex > (
-		{
-			PipelineDescription::VertexShader(std::nullopt),
-			PipelineDescription::PixelShader(std::nullopt),
-			PipelineDescription::ComputeShader(shaders::cubemap_prefiltering_cs),
-			PipelineDescription::RootSignature(root_signatures::cubemap_prefiltering),
-			PipelineDescription::DSVFormat(Format::UNKNOWN),
-			PipelineDescription::RTVFormats({ Format::UNKNOWN }),
-			PipelineDescription::NumRTVFormats(0),
-			PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-			PipelineDescription::CullMode(CullMode::CULL_NONE),
-			PipelineDescription::Depth(false),
-			PipelineDescription::CounterClockwise(false),
-			PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
-
+	{
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::cubemap_prefiltering_cs,
+		.m_root_signature_handle = root_signatures::cubemap_prefiltering,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { Format::UNKNOWN },
+		.m_num_rtv_formats = 0,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_NONE,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = false,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	/* ### Raytracing ### */
 	REGISTER(shaders::post_processing, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/post_processing.hlsl"),
-		ShaderDescription::Entry("main"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/post_processing.hlsl",
+		.entry = "main",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	REGISTER(shaders::accumulation, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/accumulation.hlsl"),
-		ShaderDescription::Entry("main"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/accumulation.hlsl",
+		.entry = "main",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	REGISTER(shaders::rt_lib, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/raytracing.hlsl"),
-		ShaderDescription::Entry("RaygenEntry"),
-		ShaderDescription::Type(ShaderType::LIBRARY_SHADER)
-		});
+		.path = "resources/shaders/raytracing.hlsl",
+		.entry = "RaygenEntry",
+		.type = ShaderType::LIBRARY_SHADER
+	});
 
 	DESC_RANGE_ARRAY(post_r,
 		DESC_RANGE(params::post_processing, Type::SRV_RANGE, params::PostProcessingE::SOURCE),
 		DESC_RANGE(params::post_processing, Type::UAV_RANGE, params::PostProcessingE::DEST),
-		);
+	);
 
 	REGISTER(root_signatures::post_processing, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(post_r, D3D12_SHADER_VISIBILITY_ALL),
 			ROOT_PARAM(GetConstants(params::post_processing, params::PostProcessingE::HDR_SUPPORT)),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_BORDER }
-		})
-		});
+		}
+	});
 
 	DESC_RANGE_ARRAY(accum_r,
 		DESC_RANGE(params::accumulation, Type::SRV_RANGE, params::AccumulationE::SOURCE),
@@ -360,46 +358,46 @@ namespace wr
 	);
 
 	REGISTER(root_signatures::accumulation, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(accum_r, D3D12_SHADER_VISIBILITY_ALL),
 			ROOT_PARAM(GetConstants(params::accumulation, params::AccumulationE::FRAME_IDX)),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_POINT, TextureAddressMode::TAM_BORDER }
-		})
-		});
+		}
+	});
 
 	REGISTER(pipelines::post_processing, PipelineRegistry) < Vertex2D > (
-		{
-			PipelineDescription::VertexShader(std::nullopt),
-			PipelineDescription::PixelShader(std::nullopt),
-			PipelineDescription::ComputeShader(shaders::post_processing),
-			PipelineDescription::RootSignature(root_signatures::post_processing),
-			PipelineDescription::DSVFormat(Format::UNKNOWN),
-			PipelineDescription::RTVFormats({ d3d12::settings::back_buffer_format }),
-			PipelineDescription::NumRTVFormats(1),
-			PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-			PipelineDescription::CullMode(CullMode::CULL_NONE),
-			PipelineDescription::Depth(false),
-			PipelineDescription::CounterClockwise(true),
-			PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+	{
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::post_processing,
+		.m_root_signature_handle = root_signatures::post_processing,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { d3d12::settings::back_buffer_format },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_NONE,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	REGISTER(pipelines::accumulation, PipelineRegistry) < Vertex2D > (
-		{
-			PipelineDescription::VertexShader(std::nullopt),
-			PipelineDescription::PixelShader(std::nullopt),
-			PipelineDescription::ComputeShader(shaders::accumulation),
-			PipelineDescription::RootSignature(root_signatures::accumulation),
-			PipelineDescription::DSVFormat(Format::UNKNOWN),
-			PipelineDescription::RTVFormats({ wr::Format::R16G16B16A16_FLOAT }),
-			PipelineDescription::NumRTVFormats(1),
-			PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-			PipelineDescription::CullMode(CullMode::CULL_NONE),
-			PipelineDescription::Depth(false),
-			PipelineDescription::CounterClockwise(true),
-			PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+	{
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::accumulation,
+		.m_root_signature_handle = root_signatures::accumulation,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { wr::Format::R16G16B16A16_FLOAT },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_NONE,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	DESC_RANGE_ARRAY(r_full_rt,
 		DESC_RANGE(params::full_raytracing, Type::UAV_RANGE, params::FullRaytracingE::OUTPUT),
@@ -415,18 +413,18 @@ namespace wr
 	);
 
 	REGISTER(root_signatures::rt_test_global, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(r_full_rt, D3D12_SHADER_VISIBILITY_ALL),
 			ROOT_PARAM(GetSRV(params::full_raytracing, params::FullRaytracingE::ACCELERATION_STRUCTURE)),
 			ROOT_PARAM(GetCBV(params::full_raytracing, params::FullRaytracingE::CAMERA_PROPERTIES)),
 			ROOT_PARAM(GetSRV(params::full_raytracing, params::FullRaytracingE::VERTICES)),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_ANISOTROPIC, TextureAddressMode::TAM_WRAP },
 			{ TextureFilter::FILTER_POINT, TextureAddressMode::TAM_CLAMP }
-		}),
-		RootSignatureDescription::ForRTX(true)
-		});
+		},
+		.m_rtx = true
+	});
 
 	StateObjectDescription::LibraryDesc rt_full_lib = []()
 	{
@@ -444,61 +442,61 @@ namespace wr
 	}();
 
 	REGISTER(state_objects::state_object, RTPipelineRegistry)(
-		{
-			StateObjectDescription::D3D12StateObjectDesc(D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE),
-			StateObjectDescription::Library(rt_full_lib),
-			StateObjectDescription::MaxPayloadSize((sizeof(float) * 7) + sizeof(unsigned int)),
-			StateObjectDescription::MaxAttributeSize(sizeof(float) * 4),
-			StateObjectDescription::MaxRecursionDepth(3),
-			StateObjectDescription::GlobalRootSignature(root_signatures::rt_test_global),
-			StateObjectDescription::LocalRootSignatures(std::nullopt),
-		});
+	{
+		.desc = D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE,
+		.library_desc = rt_full_lib,
+		.max_payload_size = (sizeof(float) * 7) + sizeof(unsigned int),
+		.max_attributes_size = sizeof(float) * 4,
+		.max_recursion_depth = 3,
+		.global_root_signature = root_signatures::rt_test_global,
+		.local_root_signatures = {},
+	});
 
 	/* ### Depth of field ### */
 
 	// Cone of confusion
 	REGISTER(shaders::dof_coc, ShaderRegistry) ({
-		ShaderDescription::Path("resources/shaders/dof_coc.hlsl"),
-			ShaderDescription::Entry("main_cs"),
-			ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/dof_coc.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	DESC_RANGE_ARRAY(dofcoc_r,
 		DESC_RANGE(params::dof_coc, Type::SRV_RANGE, params::DoFCoCE::GDEPTH),
 		DESC_RANGE(params::dof_coc, Type::UAV_RANGE, params::DoFCoCE::OUTPUT),
-		);
+	);
 
 	REGISTER(root_signatures::dof_coc, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(dofcoc_r, D3D12_SHADER_VISIBILITY_ALL),
 			ROOT_PARAM(GetCBV(params::dof_coc, params::DoFCoCE::CAMERA_PROPERTIES)),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_POINT, TextureAddressMode::TAM_CLAMP}
-		})
-		});
+		}
+	});
 
 	REGISTER(pipelines::dof_coc, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::dof_coc),
-		PipelineDescription::RootSignature(root_signatures::dof_coc),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ Format::R16_FLOAT }),
-		PipelineDescription::NumRTVFormats(1),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::dof_coc,
+		.m_root_signature_handle = root_signatures::dof_coc,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { Format::R16_FLOAT },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	// Down Scale texture
 	REGISTER(shaders::down_scale, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/down_scale.hlsl"),
-		ShaderDescription::Entry("main_cs"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/down_scale.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	DESC_RANGE_ARRAY(dscale_r,
 		DESC_RANGE(params::down_scale, Type::SRV_RANGE, params::DownScaleE::SOURCE),
@@ -506,147 +504,147 @@ namespace wr
 		DESC_RANGE(params::down_scale, Type::UAV_RANGE, params::DownScaleE::OUTPUT_FAR),
 		DESC_RANGE(params::down_scale, Type::UAV_RANGE, params::DownScaleE::OUTPUT_BRIGHT),
 		DESC_RANGE(params::down_scale, Type::SRV_RANGE, params::DownScaleE::COC),
-		);
+	);
 
 	REGISTER(root_signatures::down_scale, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(dscale_r, D3D12_SHADER_VISIBILITY_ALL),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_CLAMP},
 			{ TextureFilter::FILTER_POINT, TextureAddressMode::TAM_CLAMP}
-		})
-		});
+		}
+	});
 
 	REGISTER(pipelines::down_scale, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::down_scale),
-		PipelineDescription::RootSignature(root_signatures::down_scale),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ wr::Format::R16G16B16A16_FLOAT,wr::Format::R16G16B16A16_FLOAT, wr::Format::R16G16B16A16_FLOAT }),
-		PipelineDescription::NumRTVFormats(3),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::down_scale,
+		.m_root_signature_handle = root_signatures::down_scale,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { wr::Format::R16G16B16A16_FLOAT,wr::Format::R16G16B16A16_FLOAT, wr::Format::R16G16B16A16_FLOAT },
+		.m_num_rtv_formats = 3,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	// dof dilate
 	REGISTER(shaders::dof_dilate, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/dof_dilate.hlsl"),
-		ShaderDescription::Entry("main_cs"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/dof_dilate.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	DESC_RANGE_ARRAY(dilate_r,
 		DESC_RANGE(params::dof_dilate, Type::SRV_RANGE, params::DoFDilateE::SOURCE),
 		DESC_RANGE(params::dof_dilate, Type::UAV_RANGE, params::DoFDilateE::OUTPUT),
-		);
+	);
 
 	REGISTER(root_signatures::dof_dilate, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(dilate_r, D3D12_SHADER_VISIBILITY_ALL),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_POINT, TextureAddressMode::TAM_CLAMP}
-		})
-		});
+		}
+	});
 
 	REGISTER(pipelines::dof_dilate, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::dof_dilate),
-		PipelineDescription::RootSignature(root_signatures::dof_dilate),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ Format::R32_FLOAT }),
-		PipelineDescription::NumRTVFormats(1),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::dof_dilate,
+		.m_root_signature_handle = root_signatures::dof_dilate,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { Format::R32_FLOAT },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	// dof dilate flatten
 	REGISTER(shaders::dof_dilate_flatten, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/dof_dilate_flatten.hlsl"),
-		ShaderDescription::Entry("main_cs"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/dof_dilate_flatten.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	DESC_RANGE_ARRAY(dilate_flatten_r,
 		DESC_RANGE(params::dof_dilate_flatten, Type::SRV_RANGE, params::DoFDilateFlattenE::SOURCE),
 		DESC_RANGE(params::dof_dilate_flatten, Type::UAV_RANGE, params::DoFDilateFlattenE::OUTPUT),
-		);
+	);
 
 	REGISTER(root_signatures::dof_dilate_flatten, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(dilate_flatten_r, D3D12_SHADER_VISIBILITY_ALL),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_POINT, TextureAddressMode::TAM_CLAMP}
-		})
-		});
+		}
+	});
 
 	REGISTER(pipelines::dof_dilate_flatten, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::dof_dilate_flatten),
-		PipelineDescription::RootSignature(root_signatures::dof_dilate_flatten),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ Format::R32_FLOAT }),
-		PipelineDescription::NumRTVFormats(1),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::dof_dilate_flatten,
+		.m_root_signature_handle = root_signatures::dof_dilate_flatten,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { Format::R32_FLOAT },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	// dof dilate flatten 2nd pass
 	REGISTER(shaders::dof_dilate_flatten_h, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/dof_dilate_flatten_h.hlsl"),
-		ShaderDescription::Entry("main_cs"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/dof_dilate_flatten_h.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	DESC_RANGE_ARRAY(dilate_flattenh_r,
 		DESC_RANGE(params::dof_dilate_flatten_h, Type::SRV_RANGE, params::DoFDilateFlattenHE::SOURCE),
 		DESC_RANGE(params::dof_dilate_flatten_h, Type::UAV_RANGE, params::DoFDilateFlattenHE::OUTPUT),
-		);
+	);
 
 	REGISTER(root_signatures::dof_dilate_flatten_h, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(dilate_flattenh_r, D3D12_SHADER_VISIBILITY_ALL),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_POINT, TextureAddressMode::TAM_CLAMP}
-		})
-		});
+		}
+	});
 
 	REGISTER(pipelines::dof_dilate_flatten_h, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::dof_dilate_flatten_h),
-		PipelineDescription::RootSignature(root_signatures::dof_dilate_flatten_h),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ Format::R32_FLOAT }),
-		PipelineDescription::NumRTVFormats(1),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::dof_dilate_flatten_h,
+		.m_root_signature_handle = root_signatures::dof_dilate_flatten_h,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { Format::R32_FLOAT },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	//dof bokeh
 	REGISTER(shaders::dof_bokeh, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/dof_bokeh.hlsl"),
-		ShaderDescription::Entry("main_cs"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/dof_bokeh.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	DESC_RANGE_ARRAY(dof_bokeh_r,
 		DESC_RANGE(params::dof_bokeh, Type::SRV_RANGE, params::DoFBokehE::SOURCE_NEAR),
@@ -654,79 +652,79 @@ namespace wr
 		DESC_RANGE(params::dof_bokeh, Type::UAV_RANGE, params::DoFBokehE::OUTPUT_NEAR),
 		DESC_RANGE(params::dof_bokeh, Type::UAV_RANGE, params::DoFBokehE::OUTPUT_FAR),
 		DESC_RANGE(params::dof_bokeh, Type::SRV_RANGE, params::DoFBokehE::COC),
-		);
+	);
 
 	REGISTER(root_signatures::dof_bokeh, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(dof_bokeh_r, D3D12_SHADER_VISIBILITY_ALL),
 			ROOT_PARAM(GetCBV(params::dof_bokeh, params::DoFBokehE::CAMERA_PROPERTIES)),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_CLAMP},
 			{ TextureFilter::FILTER_POINT, TextureAddressMode::TAM_CLAMP}
-		})
-		});
+		}
+	});
 
 	REGISTER(pipelines::dof_bokeh, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::dof_bokeh),
-		PipelineDescription::RootSignature(root_signatures::dof_bokeh),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ wr::Format::R16G16B16A16_FLOAT,wr::Format::R16G16B16A16_FLOAT }),
-		PipelineDescription::NumRTVFormats(2),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::dof_bokeh,
+		.m_root_signature_handle = root_signatures::dof_bokeh,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { wr::Format::R16G16B16A16_FLOAT,wr::Format::R16G16B16A16_FLOAT },
+		.m_num_rtv_formats = 2,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	//dof bokeh post filter
 	REGISTER(shaders::dof_bokeh_post_filter, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/dof_bokeh_post_filter.hlsl"),
-		ShaderDescription::Entry("main_cs"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/dof_bokeh_post_filter.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	DESC_RANGE_ARRAY(dof_bokeh_post_filter_r,
 		DESC_RANGE(params::dof_bokeh_post_filter, Type::SRV_RANGE, params::DoFBokehPostFilterE::SOURCE_NEAR),
 		DESC_RANGE(params::dof_bokeh_post_filter, Type::SRV_RANGE, params::DoFBokehPostFilterE::SOURCE_FAR),
 		DESC_RANGE(params::dof_bokeh_post_filter, Type::UAV_RANGE, params::DoFBokehPostFilterE::OUTPUT_NEAR),
 		DESC_RANGE(params::dof_bokeh_post_filter, Type::UAV_RANGE, params::DoFBokehPostFilterE::OUTPUT_FAR),
-		);
+	);
 
 	REGISTER(root_signatures::dof_bokeh_post_filter, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(dof_bokeh_post_filter_r, D3D12_SHADER_VISIBILITY_ALL),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_CLAMP},
 			{ TextureFilter::FILTER_POINT, TextureAddressMode::TAM_CLAMP}
-		})
-		});
+		}
+	});
 
 	REGISTER(pipelines::dof_bokeh_post_filter, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::dof_bokeh_post_filter),
-		PipelineDescription::RootSignature(root_signatures::dof_bokeh_post_filter),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ wr::Format::R16G16B16A16_FLOAT, wr::Format::R16G16B16A16_FLOAT }),
-		PipelineDescription::NumRTVFormats(2),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::dof_bokeh_post_filter,
+		.m_root_signature_handle = root_signatures::dof_bokeh_post_filter,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { wr::Format::R16G16B16A16_FLOAT, wr::Format::R16G16B16A16_FLOAT },
+		.m_num_rtv_formats = 2,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	// depth of field composition
 	REGISTER(shaders::dof_composition, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/dof_composition.hlsl"),
-		ShaderDescription::Entry("main_cs"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/dof_composition.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	DESC_RANGE_ARRAY(dof_composition_r,
 		DESC_RANGE(params::dof_composition, Type::SRV_RANGE, params::DoFCompositionE::SOURCE),
@@ -734,151 +732,151 @@ namespace wr
 		DESC_RANGE(params::dof_composition, Type::SRV_RANGE, params::DoFCompositionE::BOKEH_NEAR),
 		DESC_RANGE(params::dof_composition, Type::SRV_RANGE, params::DoFCompositionE::BOKEH_FAR),
 		DESC_RANGE(params::dof_composition, Type::SRV_RANGE, params::DoFCompositionE::COC),
-		);
+	);
 
 	REGISTER(root_signatures::dof_composition, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(dof_composition_r, D3D12_SHADER_VISIBILITY_ALL),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_POINT, TextureAddressMode::TAM_CLAMP},
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_CLAMP}
-		})
-		});
+		}
+	});
 
 	REGISTER(pipelines::dof_composition, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::dof_composition),
-		PipelineDescription::RootSignature(root_signatures::dof_composition),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ wr::Format::R16G16B16A16_FLOAT }),
-		PipelineDescription::NumRTVFormats(1),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::dof_composition,
+		.m_root_signature_handle = root_signatures::dof_composition,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { wr::Format::R16G16B16A16_FLOAT },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	// bloom horizontal blur
 	REGISTER(shaders::bloom_h, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/bloom_horizontal.hlsl"),
-		ShaderDescription::Entry("main_cs"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/bloom_horizontal.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	DESC_RANGE_ARRAY(bloom_h_r,
 		DESC_RANGE(params::bloom_h, Type::SRV_RANGE, params::BloomHE::SOURCE),
 		DESC_RANGE(params::bloom_h, Type::UAV_RANGE, params::BloomHE::OUTPUT),
-		);
+	);
 
 	REGISTER(root_signatures::bloom_h, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(bloom_h_r, D3D12_SHADER_VISIBILITY_ALL),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_CLAMP}
-		})
-		});
+		}
+	});
 
 	REGISTER(pipelines::bloom_h, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::bloom_h),
-		PipelineDescription::RootSignature(root_signatures::bloom_h),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ Format::R16G16B16A16_FLOAT }),
-		PipelineDescription::NumRTVFormats(1),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::bloom_h,
+		.m_root_signature_handle = root_signatures::bloom_h,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { Format::R16G16B16A16_FLOAT },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	// bloom vertical blur
 	REGISTER(shaders::bloom_v, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/bloom_vertical.hlsl"),
-		ShaderDescription::Entry("main_cs"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/bloom_vertical.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	DESC_RANGE_ARRAY(bloom_v_r,
 		DESC_RANGE(params::bloom_v, Type::SRV_RANGE, params::BloomVE::SOURCE),
 		DESC_RANGE(params::bloom_v, Type::UAV_RANGE, params::BloomVE::OUTPUT),
-		);
+	);
 
 	REGISTER(root_signatures::bloom_v, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(bloom_v_r, D3D12_SHADER_VISIBILITY_ALL),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_CLAMP}
-		})
-		});
+		}
+	});
 
 	REGISTER(pipelines::bloom_v, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::bloom_v),
-		PipelineDescription::RootSignature(root_signatures::bloom_v),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({ Format::R16G16B16A16_FLOAT }),
-		PipelineDescription::NumRTVFormats(1),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::bloom_v,
+		.m_root_signature_handle = root_signatures::bloom_v,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = { Format::R16G16B16A16_FLOAT },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 	// bloom composition
 	REGISTER(shaders::bloom_composition, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/bloom_composition.hlsl"),
-		ShaderDescription::Entry("main_cs"),
-		ShaderDescription::Type(ShaderType::DIRECT_COMPUTE_SHADER)
-		});
+		.path = "resources/shaders/bloom_composition.hlsl",
+		.entry = "main_cs",
+		.type = ShaderType::DIRECT_COMPUTE_SHADER
+	});
 
 	DESC_RANGE_ARRAY(bloom_comp_r,
 		DESC_RANGE(params::bloom_composition, Type::SRV_RANGE, params::BloomCompositionE::SOURCE_MAIN),
 		DESC_RANGE(params::bloom_composition, Type::SRV_RANGE, params::BloomCompositionE::SOURCE_BLOOM),
 		DESC_RANGE(params::bloom_composition, Type::UAV_RANGE, params::BloomCompositionE::OUTPUT),
-		);
+	);
 
 	REGISTER(root_signatures::bloom_composition, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(bloom_comp_r, D3D12_SHADER_VISIBILITY_ALL),
 			ROOT_PARAM(GetConstants(params::bloom_composition, params::BloomCompositionE::BLOOM_PROPERTIES)),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_LINEAR, TextureAddressMode::TAM_CLAMP},
 			{ TextureFilter::FILTER_POINT, TextureAddressMode::TAM_CLAMP}
-		})
-		});
+		}
+	});
 
 	REGISTER(pipelines::bloom_composition, PipelineRegistry) < Vertex2D > ({
-		PipelineDescription::VertexShader(std::nullopt),
-		PipelineDescription::PixelShader(std::nullopt),
-		PipelineDescription::ComputeShader(shaders::bloom_composition),
-		PipelineDescription::RootSignature(root_signatures::bloom_composition),
-		PipelineDescription::DSVFormat(Format::UNKNOWN),
-		PipelineDescription::RTVFormats({d3d12::settings::back_buffer_format }),
-		PipelineDescription::NumRTVFormats(1),
-		PipelineDescription::Type(PipelineType::COMPUTE_PIPELINE),
-		PipelineDescription::CullMode(CullMode::CULL_BACK),
-		PipelineDescription::Depth(false),
-		PipelineDescription::CounterClockwise(true),
-		PipelineDescription::TopologyType(TopologyType::TRIANGLE)
-		});
+		.m_vertex_shader_handle = std::nullopt,
+		.m_pixel_shader_handle = std::nullopt,
+		.m_compute_shader_handle = shaders::bloom_composition,
+		.m_root_signature_handle = root_signatures::bloom_composition,
+		.m_dsv_format = Format::UNKNOWN,
+		.m_rtv_formats = {d3d12::settings::back_buffer_format },
+		.m_num_rtv_formats = 1,
+		.m_type = PipelineType::COMPUTE_PIPELINE,
+		.m_cull_mode = CullMode::CULL_BACK,
+		.m_depth_enabled = false,
+		.m_counter_clockwise = true,
+		.m_topology_type = TopologyType::TRIANGLE
+	});
 
 
 	/* ### Hybrid Raytracing ### */
 	REGISTER(shaders::rt_hybrid_lib, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/rt_hybrid.hlsl"),
-		ShaderDescription::Entry("RaygenEntry"),
-		ShaderDescription::Type(ShaderType::LIBRARY_SHADER)
-		});
+		.path = "resources/shaders/rt_hybrid.hlsl",
+		.entry = "RaygenEntry",
+		.type = ShaderType::LIBRARY_SHADER
+	});
 
 	DESC_RANGE_ARRAY(rt_hybrid_ranges,
 		DESC_RANGE(params::rt_hybrid, Type::UAV_RANGE, params::RTHybridE::OUTPUT),
@@ -896,17 +894,17 @@ namespace wr
 	);
 
 	REGISTER(root_signatures::rt_hybrid_global, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(rt_hybrid_ranges, D3D12_SHADER_VISIBILITY_ALL),
 			ROOT_PARAM(GetSRV(params::rt_hybrid, params::RTHybridE::ACCELERATION_STRUCTURE)),
 			ROOT_PARAM(GetCBV(params::rt_hybrid, params::RTHybridE::CAMERA_PROPERTIES)),
 			ROOT_PARAM(GetSRV(params::rt_hybrid, params::RTHybridE::VERTICES)),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_ANISOTROPIC, TextureAddressMode::TAM_WRAP }
-		}),
-		RootSignatureDescription::RTXLocal(true)
-		});
+		},
+		.m_rtx = true
+	});
 
 	StateObjectDescription::LibraryDesc rt_hybrid_so_library = []()
 	{
@@ -924,21 +922,21 @@ namespace wr
 	}();
 
 	REGISTER(state_objects::rt_hybrid_state_object, RTPipelineRegistry)(
-		{
-			StateObjectDescription::D3D12StateObjectDesc(D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE),
-			StateObjectDescription::Library(rt_hybrid_so_library),
-			StateObjectDescription::MaxPayloadSize((sizeof(float) * 6) + (sizeof(unsigned int) * 2) + (sizeof(float) * 2)),
-			StateObjectDescription::MaxAttributeSize(sizeof(float) * 4),
-			StateObjectDescription::MaxRecursionDepth(3),
-			StateObjectDescription::GlobalRootSignature(root_signatures::rt_hybrid_global),
-			StateObjectDescription::LocalRootSignatures(std::nullopt),
-		});
+	{
+		.desc = D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE,
+		.library_desc = rt_hybrid_so_library,
+		.max_payload_size = (sizeof(float) * 6) + (sizeof(unsigned int) * 2) + (sizeof(float) * 2),
+		.max_attributes_size = sizeof(float) * 4,
+		.max_recursion_depth = 3,
+		.global_root_signature = root_signatures::rt_hybrid_global,
+		.local_root_signatures = {},
+	});
 
 	/*### Raytraced Ambient Oclusion ### */
 	REGISTER(shaders::rt_ao_lib, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/ambient_occlusion.hlsl"),
-		ShaderDescription::Entry("AORaygenEntry"),
-		ShaderDescription::Type(ShaderType::LIBRARY_SHADER)
+		.path = "resources/shaders/ambient_occlusion.hlsl",
+		.entry = "AORaygenEntry",
+		.type = ShaderType::LIBRARY_SHADER
 	});
 
 	DESC_RANGE_ARRAY(rt_ao_ranges,
@@ -948,13 +946,13 @@ namespace wr
 	);
 
 	REGISTER(root_signatures::rt_ao_global, RootSignatureRegistry)({
-	RootSignatureDescription::Parameters({
-		ROOT_PARAM_DESC_TABLE(rt_ao_ranges, D3D12_SHADER_VISIBILITY_ALL),
-		ROOT_PARAM(GetSRV(params::rt_ao, params::RTAOE::ACCELERATION_STRUCTURE)),
-		ROOT_PARAM(GetCBV(params::rt_ao, params::RTAOE::CAMERA_PROPERTIES)),
-	}),
-	RootSignatureDescription::Samplers({}),
-	RootSignatureDescription::RTXLocal(true)
+		.m_parameters = {
+			ROOT_PARAM_DESC_TABLE(rt_ao_ranges, D3D12_SHADER_VISIBILITY_ALL),
+			ROOT_PARAM(GetSRV(params::rt_ao, params::RTAOE::ACCELERATION_STRUCTURE)),
+			ROOT_PARAM(GetCBV(params::rt_ao, params::RTAOE::CAMERA_PROPERTIES)),
+		},
+		.m_samplers = {},
+		.m_rtx = true
 	});
 
 	StateObjectDescription::LibraryDesc rt_ao_so_library = []()
@@ -970,21 +968,21 @@ namespace wr
 
 	REGISTER(state_objects::rt_ao_state_opbject, RTPipelineRegistry)(
 	{
-		StateObjectDescription::D3D12StateObjectDesc(D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE),
-		StateObjectDescription::Library(rt_ao_so_library),
-		StateObjectDescription::MaxPayloadSize( (sizeof(float) * 2 )),  
-		StateObjectDescription::MaxAttributeSize(sizeof(float) * 4),
-		StateObjectDescription::MaxRecursionDepth(1),
-		StateObjectDescription::GlobalRootSignature(root_signatures::rt_ao_global),
-			StateObjectDescription::LocalRootSignatures(std::nullopt),
+		.desc = D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE,
+		.library_desc = rt_ao_so_library,
+		.max_payload_size =  (sizeof(float) * 2), 
+		.max_attributes_size = sizeof(float) * 4,
+		.max_recursion_depth = 1,
+		.global_root_signature = root_signatures::rt_ao_global,
+		.local_root_signatures = {},
 	});
 	
 	/* ### Path Tracer ### */
 	REGISTER(shaders::path_tracer_lib, ShaderRegistry)({
-		ShaderDescription::Path("resources/shaders/path_tracer.hlsl"),
-		ShaderDescription::Entry("RaygenEntry"),
-		ShaderDescription::Type(ShaderType::LIBRARY_SHADER)
-		});
+		.path = "resources/shaders/path_tracer.hlsl",
+		.entry = "RaygenEntry",
+		.type = ShaderType::LIBRARY_SHADER
+	});
 
 	DESC_RANGE_ARRAY(path_tracer_ranges,
 		DESC_RANGE(params::path_tracing, Type::UAV_RANGE, params::PathTracingE::OUTPUT),
@@ -1002,17 +1000,17 @@ namespace wr
 	);
 
 	REGISTER(root_signatures::path_tracing_global, RootSignatureRegistry)({
-		RootSignatureDescription::Parameters({
+		.m_parameters = {
 			ROOT_PARAM_DESC_TABLE(path_tracer_ranges, D3D12_SHADER_VISIBILITY_ALL),
 			ROOT_PARAM(GetSRV(params::path_tracing, params::PathTracingE::ACCELERATION_STRUCTURE)),
 			ROOT_PARAM(GetCBV(params::path_tracing, params::PathTracingE::CAMERA_PROPERTIES)),
 			ROOT_PARAM(GetSRV(params::path_tracing, params::PathTracingE::VERTICES)),
-		}),
-		RootSignatureDescription::Samplers({
+		},
+		.m_samplers = {
 			{ TextureFilter::FILTER_ANISOTROPIC, TextureAddressMode::TAM_WRAP }
-		}),
-		RootSignatureDescription::RTXLocal(true)
-		});
+		},
+		.m_rtx = true
+	});
 
 	StateObjectDescription::LibraryDesc path_tracer_so_library = []()
 	{
@@ -1030,14 +1028,14 @@ namespace wr
 	}();
 
 	REGISTER(state_objects::path_tracer_state_object, RTPipelineRegistry)(
-		{
-			StateObjectDescription::D3D12StateObjectDesc(D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE),
-			StateObjectDescription::Library(path_tracer_so_library),
-			StateObjectDescription::MaxPayloadSize((sizeof(float) * 7) + (sizeof(unsigned int) * 1)),
-			StateObjectDescription::MaxAttributeSize(sizeof(float) * 4),
-			StateObjectDescription::MaxRecursionDepth(6),
-			StateObjectDescription::GlobalRootSignature(root_signatures::path_tracing_global),
-			StateObjectDescription::LocalRootSignatures(std::nullopt),
-		});
+	{
+		.desc = D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE,
+		.library_desc = path_tracer_so_library,
+		.max_payload_size = (sizeof(float) * 7) + (sizeof(unsigned int) * 1),
+		.max_attributes_size = sizeof(float) * 4,
+		.max_recursion_depth = 6,
+		.global_root_signature = root_signatures::path_tracing_global,
+		.local_root_signatures = {},
+	});
 
 } /* wr */

--- a/src/imgui_tools.cpp
+++ b/src/imgui_tools.cpp
@@ -530,15 +530,15 @@ namespace wr::imgui::window
 					obj = obj_it->second;
 				}
 
-				std::string tree_name = internal::ShaderTypeToStr(desc.second.type) + "[" + std::to_string(desc.first) + "]: " + desc.second.path.Get();
+				std::string tree_name = internal::ShaderTypeToStr(desc.second.type) + "[" + std::to_string(desc.first) + "]: " + desc.second.path;
 				if (ImGui::TreeNode(tree_name.c_str()))
 				{
 					if (ImGui::TreeNode("Description"))
 					{
 						ImGui::Text("ID: %d", desc.first);
-						ImGui::Text("Path: %s", desc.second.path.Get().c_str());
-						ImGui::Text("Entry: %s", desc.second.entry.Get().c_str());
-						ImGui::Text("Type: %s", internal::ShaderTypeToStr(desc.second.type.Get()).c_str());
+						ImGui::Text("Path: %s", desc.second.path.c_str());
+						ImGui::Text("Entry: %s", desc.second.entry.c_str());
+						ImGui::Text("Type: %s", internal::ShaderTypeToStr(desc.second.type).c_str());
 
 						ImGui::TreePop();
 					}
@@ -591,10 +591,10 @@ namespace wr::imgui::window
 							}
 						};
 
-						text_handle("Vertex Shader", desc.second.m_vertex_shader_handle.Get());
-						text_handle("Pixel Shader", desc.second.m_pixel_shader_handle.Get());
-						text_handle("Compute Shader", desc.second.m_compute_shader_handle.Get());
-						text_handle("RootSignature", desc.second.m_root_signature_handle.Get());
+						text_handle("Vertex Shader", desc.second.m_vertex_shader_handle);
+						text_handle("Pixel Shader", desc.second.m_pixel_shader_handle);
+						text_handle("Compute Shader", desc.second.m_compute_shader_handle);
+						text_handle("RootSignature", desc.second.m_root_signature_handle);
 						
 						ImGui::Text("Depth Enabled: %s", internal::BooltoStr(desc.second.m_depth_enabled).c_str());
 						ImGui::Text("Counter Clockwise Winding Order: %s", internal::BooltoStr(desc.second.m_counter_clockwise).c_str());
@@ -602,7 +602,7 @@ namespace wr::imgui::window
 						for (auto i = 0u; i < desc.second.m_num_rtv_formats; i++)
 						{
 							std::string text = "Format[" + std::to_string(i) + "]: %s";
-							ImGui::Text(text.c_str(), FormatToStr(desc.second.m_rtv_formats.Get()[i]).c_str());
+							ImGui::Text(text.c_str(), FormatToStr(desc.second.m_rtv_formats[i]).c_str());
 						}
 
 						ImGui::TreePop();
@@ -647,15 +647,12 @@ namespace wr::imgui::window
 							}
 						};
 
-						text_handle("Library Shader", desc.second.library_desc.Get().shader_handle);
-						text_handle("Global RootSignature", desc.second.global_root_signature.Get().value_or(-1));
+						text_handle("Library Shader", desc.second.library_desc.shader_handle);
+						text_handle("Global RootSignature", desc.second.global_root_signature.value_or(-1));
 
-						if (desc.second.local_root_signatures.Get().has_value())
+						for (auto i = 0; i < desc.second.local_root_signatures.size(); i++)
 						{
-							for (auto i = 0; i < desc.second.local_root_signatures.Get().value().size(); i++)
-							{
-								ImGui::Text("Local Root Signature [%d] = %d", i, desc.second.local_root_signatures.Get().value()[i]);
-							}
+							ImGui::Text("Local Root Signature [%d] = %d", i, desc.second.local_root_signatures[i]);
 						}
 
 						ImGui::TreePop();
@@ -732,8 +729,8 @@ namespace wr::imgui::window
 							}
 						};
 
-						ImGui::Text("Num samplers: %d", desc.second.m_samplers.Get().size());
-						ImGui::Text("Num parameters: %d", desc.second.m_parameters.Get().size());
+						ImGui::Text("Num samplers: %d", desc.second.m_samplers.size());
+						ImGui::Text("Num parameters: %d", desc.second.m_parameters.size());
 
 						ImGui::TreePop();
 					}

--- a/src/pipeline_registry.hpp
+++ b/src/pipeline_registry.hpp
@@ -16,37 +16,22 @@ namespace wr
 
 	struct PipelineDescription
 	{
-		using VertexShader = util::NamedType<std::optional<RegistryHandle>>;
-		using PixelShader = util::NamedType<std::optional<RegistryHandle>>;
-		using ComputeShader = util::NamedType<std::optional<RegistryHandle>>;
-		using RootSignature = util::NamedType<RegistryHandle>;
-		using DSVFormat = util::NamedType<Format>;
-		using RTVFormats = util::NamedType<std::array<Format, 8>>;
-		using NumRTVFormats = util::NamedType<unsigned int>;
-		using Type = util::NamedType<PipelineType>;
-		using CullMode = util::NamedType<CullMode>;
-		using Depth = util::NamedType<bool>;
-		using CounterClockwise = util::NamedType<bool>;
-		using TopologyType = util::NamedType<TopologyType>;
-		using InputLayout = util::NamedType<std::vector<D3D12_INPUT_ELEMENT_DESC>>;
+		std::optional<RegistryHandle> m_vertex_shader_handle;
+		std::optional<RegistryHandle> m_pixel_shader_handle;
+		std::optional<RegistryHandle> m_compute_shader_handle;
+		RegistryHandle m_root_signature_handle;
 
+		Format m_dsv_format;
+		std::array<Format, 8> m_rtv_formats;
+		unsigned int m_num_rtv_formats;
 
-		VertexShader m_vertex_shader_handle;
-		PixelShader m_pixel_shader_handle;
-		ComputeShader m_compute_shader_handle;
-		RootSignature m_root_signature_handle;
+		PipelineType m_type = PipelineType::GRAPHICS_PIPELINE;
+		CullMode m_cull_mode = wr::CullMode::CULL_BACK;
+		bool m_depth_enabled = false;
+		bool m_counter_clockwise = false;
+		TopologyType m_topology_type = wr::TopologyType::TRIANGLE;
 
-		DSVFormat m_dsv_format;
-		RTVFormats m_rtv_formats;
-		NumRTVFormats m_num_rtv_formats;
-
-		Type m_type = Type(PipelineType::GRAPHICS_PIPELINE);
-		CullMode m_cull_mode = CullMode(wr::CullMode::CULL_BACK);
-		Depth m_depth_enabled = Depth(false);
-		CounterClockwise m_counter_clockwise = CounterClockwise(false);
-		TopologyType m_topology_type = TopologyType(wr::TopologyType::TRIANGLE);
-
-		InputLayout m_input_layout = InputLayout({});
+		std::vector<D3D12_INPUT_ELEMENT_DESC> m_input_layout = {};
 	};
 
 	class PipelineRegistry : public internal::Registry<PipelineRegistry, Pipeline, PipelineDescription>
@@ -66,7 +51,7 @@ namespace wr
 
 		auto handle = m_next_handle;
 
-		description.m_input_layout.Get() = VT::GetInputLayout();
+		description.m_input_layout = VT::GetInputLayout();
 		m_descriptions.insert({ handle, description });
 
 		m_next_handle++;

--- a/src/renderer.hpp
+++ b/src/renderer.hpp
@@ -46,6 +46,10 @@ namespace wr
 		virtual void PrepareShaderRegistry() = 0;
 		virtual void PreparePipelineRegistry() = 0;
 		virtual void PrepareRTPipelineRegistry() = 0;
+		virtual void DestroyRootSignatureRegistry() = 0;
+		virtual void DestroyShaderRegistry() = 0;
+		virtual void DestroyPipelineRegistry() = 0;
+		virtual void DestroyRTPipelineRegistry() = 0;
 
 		virtual void WaitForAllPreviousWork() = 0;
 

--- a/src/root_signature_registry.hpp
+++ b/src/root_signature_registry.hpp
@@ -15,17 +15,11 @@ namespace wr
 
 	struct RootSignatureDescription
 	{
-		using Parameters = util::NamedType<std::vector<CD3DX12_ROOT_PARAMETER>>;
-		using Samplers = util::NamedType<std::vector<d3d12::desc::SamplerDesc>>;
-		using ForRTX = util::NamedType<bool>;
-		using RTXLocal = util::NamedType<bool>;
-		using Name = util::NamedType<std::wstring>;
-
-		Parameters m_parameters; // TODO: Write platform independend version.
-		Samplers m_samplers; // TODO: Move to platform independed location
-		ForRTX m_rtx = ForRTX(false);
-		RTXLocal m_rtx_local = RTXLocal(false);
-		Name name = Name(L"Unknown root signature");
+		std::vector<CD3DX12_ROOT_PARAMETER> m_parameters; // TODO: Write platform independend version.
+		std::vector<d3d12::desc::SamplerDesc> m_samplers; // TODO: Move to platform independed location
+		bool m_rtx = false;
+		bool m_rtx_local = false;
+		std::wstring name = L"Unknown root signature";
 	};
 
 	class RootSignatureRegistry : public internal::Registry<RootSignatureRegistry, RootSignature, RootSignatureDescription>

--- a/src/rt_pipeline_registry.hpp
+++ b/src/rt_pipeline_registry.hpp
@@ -24,23 +24,15 @@ namespace wr
 			std::vector<std::pair<std::wstring, std::wstring>> m_hit_groups; // first = hit group | second = entry
 		};
 
-		using Library = util::NamedType<LibraryDesc>;
-		using D3D12StateObjectDesc = util::NamedType<CD3DX12_STATE_OBJECT_DESC>;
-		using MaxPayloadSize = util::NamedType<std::uint64_t>;
-		using MaxAttributeSize = util::NamedType<std::uint64_t>;
-		using MaxRecursionDepth = util::NamedType<std::uint64_t>;
-		using GlobalRootSignature = util::NamedType<std::optional<RegistryHandle>>;
-		using LocalRootSignatures = util::NamedType<std::optional<std::vector<RegistryHandle>>>;
+		CD3DX12_STATE_OBJECT_DESC desc;
+		LibraryDesc library_desc;
 
-		D3D12StateObjectDesc desc;
-		Library library_desc;
+		std::uint64_t max_payload_size;
+		std::uint64_t max_attributes_size;
+		std::uint64_t max_recursion_depth;
 
-		MaxPayloadSize max_payload_size;
-		MaxAttributeSize max_attributes_size;
-		MaxRecursionDepth max_recursion_depth;
-
-		GlobalRootSignature global_root_signature;
-		LocalRootSignatures local_root_signatures;
+		std::optional<RegistryHandle> global_root_signature;
+		std::vector<RegistryHandle> local_root_signatures;
 	};
 
 	class RTPipelineRegistry : public internal::Registry<RTPipelineRegistry, StateObject, StateObjectDescription>

--- a/src/shader_registry.hpp
+++ b/src/shader_registry.hpp
@@ -10,13 +10,9 @@ namespace wr
 
 	struct ShaderDescription
 	{
-		using Path = util::NamedType<std::string>;
-		using Entry = util::NamedType<std::string>;
-		using Type = util::NamedType<ShaderType>;
-
-		Path path;
-		Entry entry;
-		Type type;
+		std::string path;
+		std::string entry;
+		ShaderType type;
 	};
 
 	class ShaderRegistry : public internal::Registry<ShaderRegistry, Shader, ShaderDescription>

--- a/src/util/file_watcher.cpp
+++ b/src/util/file_watcher.cpp
@@ -72,7 +72,7 @@ namespace util
 				auto file_path = file.path().u8string();
 
 				// File Created
-				if (!PathsContains(file_path))
+				if (!m_paths.contains(file_path))
 				{
 					m_paths[file_path] = last_write_time;
 					run_callback(file_path, FileStatus::CREATED);
@@ -101,12 +101,6 @@ namespace util
 		m_thread = std::thread([this, callback]() {
 			Start(callback);
 		});
-	}
-
-	bool FileWatcher::PathsContains(std::string const & key)
-	{
-		auto it = m_paths.find(key);
-		return it != m_paths.end();
 	}
 
 } /* util */

--- a/src/util/file_watcher.hpp
+++ b/src/util/file_watcher.hpp
@@ -43,9 +43,6 @@ namespace util
 		void StartAsync(util::Delegate<void(std::string const &, FileStatus)> const & callback);
 
 	private:
-		//! C++20's path::contains function.
-		bool PathsContains(std::string const & key);
-
 		bool m_running;
 		bool m_regular_files_only;
 		const std::chrono::milliseconds m_delay;


### PR DESCRIPTION
* Registries now get destroyed properly.
* Removed the named type from the registries in favor of designated initialization.
* Now using std's `contains` function instead of my own.