### PR TITLE
[FIX] Fixed meshes randomly starting as hidden.

### DIFF
--- a/src/scene_graph/mesh_node.cpp
+++ b/src/scene_graph/mesh_node.cpp
@@ -2,7 +2,7 @@
 
 namespace wr {
 
-	MeshNode::MeshNode(Model* model) : Node(typeid(MeshNode)), m_model(model), m_materials()
+	MeshNode::MeshNode(Model* model) : Node(typeid(MeshNode)), m_model(model), m_materials(), m_visible(true)
 	{
 	}
 


### PR DESCRIPTION
Fixed meshes randomly starting as hidden when running on release, caused by the variable not being initialized properly, thus initializing to a random value on release.