### PR TITLE
Throw on texture load fail

### DIFF
--- a/src/d3d12/d3d12_resource_pool_texture.cpp
+++ b/src/d3d12/d3d12_resource_pool_texture.cpp
@@ -462,7 +462,8 @@ namespace wr
 			}
 			else
 			{
-				LOGC("Texture {} not loaded. Format not supported.", path);
+				LOGE("Texture {} not loaded. Format not supported.", path);
+				throw std::exception("Texture format not supported. Check the output for more information.");
 				return {};
 			}
 
@@ -471,7 +472,9 @@ namespace wr
 				_com_error err(hr);
 				LPCTSTR errMsg = err.ErrorMessage();
 
-				LOGC("ERROR: DirectXTex error: {}", errMsg);
+				LOGE("ERROR: DirectXTex error: {}", errMsg);
+				throw std::exception("A DirectXTex error occured! Check the output for more information.");
+				return {};
 			}
 		}
 

--- a/src/d3d12/d3d12_resource_pool_texture.cpp
+++ b/src/d3d12/d3d12_resource_pool_texture.cpp
@@ -463,7 +463,6 @@ namespace wr
 			else
 			{
 				LOGE("Texture {} not loaded. Format not supported.", path);
-				throw std::exception("Texture format not supported. Check the output for more information.");
 				return {};
 			}
 
@@ -473,7 +472,6 @@ namespace wr
 				LPCTSTR errMsg = err.ErrorMessage();
 
 				LOGE("ERROR: DirectXTex error: {}", errMsg);
-				throw std::exception("A DirectXTex error occured! Check the output for more information.");
 				return {};
 			}
 		}

--- a/src/d3d12/d3d12_resource_pool_texture.cpp
+++ b/src/d3d12/d3d12_resource_pool_texture.cpp
@@ -462,6 +462,7 @@ namespace wr
 			}
 			else
 			{
+				// Return an invalid texture handle when format is not supported
 				LOGE("Texture {} not loaded. Format not supported.", path);
 				return {};
 			}
@@ -471,6 +472,7 @@ namespace wr
 				_com_error err(hr);
 				LPCTSTR errMsg = err.ErrorMessage();
 
+				// Return an invalid texture handle when texture couldn't be loaded
 				LOGE("ERROR: DirectXTex error: {}", errMsg);
 				return {};
 			}

--- a/src/d3d12/d3d12_resource_pool_texture.hpp
+++ b/src/d3d12/d3d12_resource_pool_texture.hpp
@@ -61,9 +61,14 @@ namespace wr
 
 		d3d12::TextureResource* GetTextureResource(TextureHandle handle) final;
 
-		// Load a texture from file.
-		// Returns the texture handle to the loaded texture.
-		// When the texture failed to load it returns an invalid texture handle.
+		//! Loads a texture from file.
+		/*!
+		  \param path std::string that contains a path to the texture file location.
+		  \param srgb Defines if the texture should be loaded as srgb texture or not (currently not supported). 
+		  \param generate_mips Defines if mipmaps should be created.
+		  \return The texture handle to the loaded texture.
+		  \sa wr::TextureHandle
+		*/
 		[[nodiscard]] TextureHandle LoadFromFile(std::string_view path, bool srgb, bool generate_mips) final;
 		[[nodiscard]] TextureHandle LoadFromMemory(unsigned char* data, size_t width, size_t height, TextureFormat type, bool srgb, bool generate_mips) final;
 		[[nodiscard]] TextureHandle CreateCubemap(std::string_view name, uint32_t width, uint32_t height, uint32_t mip_levels, Format format, bool allow_render_dest) final;

--- a/src/d3d12/d3d12_resource_pool_texture.hpp
+++ b/src/d3d12/d3d12_resource_pool_texture.hpp
@@ -60,6 +60,10 @@ namespace wr
 		void ReleaseTemporaryResources() final;
 
 		d3d12::TextureResource* GetTextureResource(TextureHandle handle) final;
+
+		// Load a texture from file.
+		// Returns the texture handle to the loaded texture.
+		// When the texture failed to load it returns an invalid texture handle.
 		[[nodiscard]] TextureHandle LoadFromFile(std::string_view path, bool srgb, bool generate_mips) final;
 		[[nodiscard]] TextureHandle LoadFromMemory(unsigned char* data, size_t width, size_t height, TextureFormat type, bool srgb, bool generate_mips) final;
 		[[nodiscard]] TextureHandle CreateCubemap(std::string_view name, uint32_t width, uint32_t height, uint32_t mip_levels, Format format, bool allow_render_dest) final;


### PR DESCRIPTION
In WispForMaya, we have to catch when a texture failed to load. A LOGC triggers a debug break which WispForMaya can't catch. I changed this to LOGE (so it still outputs the error) and it now returns an invalid texture handle. So, whenever a texture failed to load, WispForMaya can catch it and handle it accordingly.