### PR TITLE
Fix BLAS dereference

### DIFF
--- a/src/render_tasks/d3d12_build_acceleration_structures.hpp
+++ b/src/render_tasks/d3d12_build_acceleration_structures.hpp
@@ -388,7 +388,9 @@ namespace wr
 
 						if (blas_iterator == data.blasses.end() || n_mesh->data_changed)
 						{
-							if (n_mesh->data_changed)
+							// Check if data changed in the mesh and if the blas iterator isn't an end iterator,
+							// since it will be dereferenced (end iterators can't be dereferenced).
+							if (n_mesh->data_changed && blas_iterator != data.blasses.end())
 							{
 								data.old_blasses[data.current_frame_index].push_back((*blas_iterator).second);
 								data.blasses.erase(blas_iterator);


### PR DESCRIPTION
This PR fixes crashes when adding new models in runtime. The issue was that the `blas_iterator` was equal to the end iterator. Though, when `data_changed` of the mesh is `true`, it wants to dereference the `blas_iterator` but you can't dereference end iterators obviously.