### PR TITLE
Switch depth buffer to position buffer with ray-tracing

### DIFF
--- a/resources/shaders/dxr_reflection_main.hlsl
+++ b/resources/shaders/dxr_reflection_main.hlsl
@@ -44,6 +44,7 @@ Texture2D g_textures[1000] : register(t10);
 Texture2D gbuffer_albedo : register(t1010);
 Texture2D gbuffer_normal : register(t1011);
 Texture2D gbuffer_depth : register(t1012);
+Texture2D gbuffer_position : register(t1013);
 TextureCube skybox : register(t6);
 Texture2D brdf_lut : register(t8);
 TextureCube irradiance_map : register(t9);
@@ -84,7 +85,7 @@ void ReflectionRaygenEntry()
 
 	// Unpack G-Buffer
 	float depth = gbuffer_depth.SampleLevel(s0, uv, 0).x;
-	float3 wpos = unpack_position(float2(uv.x, 1.f - uv.y), depth, inv_vp);
+	float3 wpos = gbuffer_position.SampleLevel(s0, uv, 0).xyz;
 	float3 albedo = albedo_roughness.rgb;
 	float roughness = albedo_roughness.w;
 	float3 normal = normal_metallic.xyz;

--- a/resources/shaders/dxr_shadow_main.hlsl
+++ b/resources/shaders/dxr_shadow_main.hlsl
@@ -44,6 +44,7 @@ Texture2D g_textures[1000] : register(t10);
 Texture2D gbuffer_albedo : register(t1010);
 Texture2D gbuffer_normal : register(t1011);
 Texture2D gbuffer_depth : register(t1012);
+Texture2D gbuffer_position : register(t1013);
 TextureCube skybox : register(t6);
 Texture2D brdf_lut : register(t8);
 TextureCube irradiance_map : register(t9);
@@ -83,7 +84,7 @@ void ShadowRaygenEntry()
 
 	// Unpack G-Buffer
 	float depth = gbuffer_depth[screen_co].x;
-	float3 wpos = unpack_position(float2(uv.x, 1.f - uv.y), depth, inv_vp);
+	float3 wpos = gbuffer_position.SampleLevel(s0, uv, 0).xyz;
 	float3 normal = normal_metallic.xyz;
 
 	// Do lighting

--- a/src/engine_registry.hpp
+++ b/src/engine_registry.hpp
@@ -529,7 +529,7 @@ namespace wr
 			rs_layout::Entry{(int)RTHybridE::BRDF_LUT, 1, rs_layout::Type::SRV_RANGE},
 			rs_layout::Entry{(int)RTHybridE::IRRADIANCE_MAP, 1, rs_layout::Type::SRV_RANGE},
 			rs_layout::Entry{(int)RTHybridE::TEXTURES, d3d12::settings::num_max_rt_textures, rs_layout::Type::SRV_RANGE},
-			rs_layout::Entry{(int)RTHybridE::GBUFFERS, 3, rs_layout::Type::SRV_RANGE},
+			rs_layout::Entry{(int)RTHybridE::GBUFFERS, 4, rs_layout::Type::SRV_RANGE},
 			rs_layout::Entry{(int)RTHybridE::FALLBACK_PTRS, 9, rs_layout::Type::SRV_RANGE},
 		};
 

--- a/src/render_tasks/d3d12_rt_hybrid_helpers.hpp
+++ b/src/render_tasks/d3d12_rt_hybrid_helpers.hpp
@@ -59,6 +59,7 @@ namespace wr
 		DescriptorAllocation out_gbuffer_albedo_alloc;
 		DescriptorAllocation out_gbuffer_normal_alloc;
 		DescriptorAllocation out_gbuffer_depth_alloc;
+		DescriptorAllocation out_gbuffer_position_alloc;
 
 		bool tlas_requires_init = false;
 	};
@@ -147,11 +148,13 @@ namespace wr
 				auto albedo_handle = data.out_gbuffer_albedo_alloc.GetDescriptorHandle();
 				auto normal_handle = data.out_gbuffer_normal_alloc.GetDescriptorHandle();
 				auto depth_handle = data.out_gbuffer_depth_alloc.GetDescriptorHandle();
+				auto position_handle = data.out_gbuffer_position_alloc.GetDescriptorHandle();
 
 				auto deferred_main_rt = data.out_deferred_main_rt = static_cast<d3d12::RenderTarget*>(fg.GetPredecessorRenderTarget<DeferredMainTaskData>());
 
 				d3d12::CreateSRVFromSpecificRTV(deferred_main_rt, albedo_handle, 0, deferred_main_rt->m_create_info.m_rtv_formats[0]);
 				d3d12::CreateSRVFromSpecificRTV(deferred_main_rt, normal_handle, 1, deferred_main_rt->m_create_info.m_rtv_formats[1]);
+				d3d12::CreateSRVFromSpecificRTV(deferred_main_rt, position_handle, 5, deferred_main_rt->m_create_info.m_rtv_formats[5]);
 
 				d3d12::CreateSRVFromDSV(deferred_main_rt, depth_handle);
 			}

--- a/src/render_tasks/d3d12_rt_reflection_task.hpp
+++ b/src/render_tasks/d3d12_rt_reflection_task.hpp
@@ -58,6 +58,7 @@ namespace wr
 				data.base_data.out_gbuffer_albedo_alloc = std::move(as_build_data.out_allocator->Allocate());
 				data.base_data.out_gbuffer_normal_alloc = std::move(as_build_data.out_allocator->Allocate());
 				data.base_data.out_gbuffer_depth_alloc = std::move(as_build_data.out_allocator->Allocate());
+				data.base_data.out_gbuffer_position_alloc = std::move(as_build_data.out_allocator->Allocate());
 				
 				data.base_data.tlas_requires_init = true;
 			}
@@ -142,6 +143,8 @@ namespace wr
 				auto out_scene_depth_handle = data.base_data.out_gbuffer_depth_alloc.GetDescriptorHandle();
 				d3d12::SetRTShaderSRV(cmd_list, 0, COMPILATION_EVAL(rs_layout::GetHeapLoc(params::rt_hybrid, params::RTHybridE::GBUFFERS)) + 2, out_scene_depth_handle);
 
+				auto out_scene_position_handle = data.base_data.out_gbuffer_position_alloc.GetDescriptorHandle();
+				d3d12::SetRTShaderSRV(cmd_list, 0, COMPILATION_EVAL(rs_layout::GetHeapLoc(params::rt_hybrid, params::RTHybridE::GBUFFERS)) + 3, out_scene_position_handle);
 				/*
 				To keep the CopyDescriptors function happy, we need to fill the descriptor table with valid descriptors
 				We fill the table with a single descriptor, then overwrite some spots with the he correct textures
@@ -294,6 +297,7 @@ namespace wr
 				std::move(data.base_data.out_gbuffer_albedo_alloc);
 				std::move(data.base_data.out_gbuffer_normal_alloc);
 				std::move(data.base_data.out_gbuffer_depth_alloc);
+				std::move(data.base_data.out_gbuffer_position_alloc);
 			}
 		}
 

--- a/src/render_tasks/d3d12_rt_shadow_task.hpp
+++ b/src/render_tasks/d3d12_rt_shadow_task.hpp
@@ -70,6 +70,7 @@ namespace wr
 				data.base_data.out_gbuffer_albedo_alloc = std::move(as_build_data.out_allocator->Allocate());
 				data.base_data.out_gbuffer_normal_alloc = std::move(as_build_data.out_allocator->Allocate());
 				data.base_data.out_gbuffer_depth_alloc = std::move(as_build_data.out_allocator->Allocate());
+				data.base_data.out_gbuffer_position_alloc = std::move(as_build_data.out_allocator->Allocate());
 
 				data.base_data.tlas_requires_init = true;
 			}
@@ -156,6 +157,9 @@ namespace wr
 
 				auto out_scene_depth_handle = data.base_data.out_gbuffer_depth_alloc.GetDescriptorHandle();
 				d3d12::SetRTShaderSRV(cmd_list, 0, COMPILATION_EVAL(rs_layout::GetHeapLoc(params::rt_hybrid, params::RTHybridE::GBUFFERS)) + 2, out_scene_depth_handle);
+
+				auto out_scene_position_handle = data.base_data.out_gbuffer_position_alloc.GetDescriptorHandle();
+				d3d12::SetRTShaderSRV(cmd_list, 0, COMPILATION_EVAL(rs_layout::GetHeapLoc(params::rt_hybrid, params::RTHybridE::GBUFFERS)) + 3, out_scene_position_handle);
 
 				/*
 				To keep the CopyDescriptors function happy, we need to fill the descriptor table with valid descriptors
@@ -311,6 +315,7 @@ namespace wr
 				std::move(data.base_data.out_gbuffer_albedo_alloc);
 				std::move(data.base_data.out_gbuffer_normal_alloc);
 				std::move(data.base_data.out_gbuffer_depth_alloc);
+				std::move(data.base_data.out_gbuffer_position_alloc);
 			}
 		}
 


### PR DESCRIPTION
The reflection and shadow ray-tracing tasks now use the position buffer instead of the depth buffer, removing the need to change Epsilon depending on scene size.