### PR TITLE
Fixed some minor issues in the bloom and post processing tasks

### DIFF
--- a/src/render_tasks/d3d12_bloom_composition.hpp
+++ b/src/render_tasks/d3d12_bloom_composition.hpp
@@ -141,8 +141,8 @@ namespace wr
 
 
 
-			int enable_dof = settings.m_runtime.m_enable_bloom;
-			d3d12::BindCompute32BitConstants(cmd_list, &enable_dof, 1, 0, 1);
+			int enable_bloom = settings.m_runtime.m_enable_bloom;
+			d3d12::BindCompute32BitConstants(cmd_list, &enable_bloom, 1, 0, 1);
 
 			//cmd_list->m_dynamic_descriptor_heaps[D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV]->StageDescriptors(0, 0, 3, data.out_allocation.GetDescriptorHandle());
 			{

--- a/src/render_tasks/d3d12_post_processing.hpp
+++ b/src/render_tasks/d3d12_post_processing.hpp
@@ -32,7 +32,7 @@ namespace wr
 		DescriptorAllocation out_allocation;
 	};
 
-	int versions = 1;
+	const constexpr int versions = 1;
 
 	namespace internal
 	{


### PR DESCRIPTION
The bloom task contained a typo which made it difficult to understand the code.
The post processing task had a constant that had to be turned into a const constexpr.