### PR TITLE
Unnecessary destroy on resize

### DIFF
--- a/src/render_tasks/d3d12_equirect_to_cubemap.hpp
+++ b/src/render_tasks/d3d12_equirect_to_cubemap.hpp
@@ -322,7 +322,7 @@ namespace wr
 			internal::ExecuteEquirectToCubemapTask(rs, fg, sg, handle);
 		};
 		desc.m_destroy_func = [](FrameGraph& fg, RenderTaskHandle handle, bool resize) {
-			if(resize)
+			if(!resize)
 			{
 				auto &data = fg.GetData<EquirectToCubemapTaskData>(handle);
 				data.camera_cb_pool.reset();


### PR DESCRIPTION
This PR fixes an issue where the camera constant buffer pool was destroyed on resizing. This should've only happened when actually destroy the render task (equirect to cubemap). 